### PR TITLE
Update default configuration to include HTTP.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'cloud.filibuster'
             artifactId = 'instrumentation'
-            version = "0.27-SNAPSHOT"
+            version = "0.28-SNAPSHOT"
             from components.java
 
             pom {

--- a/src/main/java/cloud/filibuster/junit/FilibusterTest.java
+++ b/src/main/java/cloud/filibuster/junit/FilibusterTest.java
@@ -7,6 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import cloud.filibuster.junit.configuration.FilibusterAnalysisConfigurationFile;
+import cloud.filibuster.junit.configuration.FilibusterDefaultAnalysisConfigurationFile;
 import cloud.filibuster.junit.configuration.FilibusterGrpcBasicAnalysisConfigurationFile;
 import cloud.filibuster.junit.extensions.FilibusterTestExtension;
 
@@ -150,5 +151,5 @@ public @interface FilibusterTest {
      *
      * @return custom analysis configuration file.
      */
-    Class<? extends FilibusterAnalysisConfigurationFile> analysisConfigurationFile() default FilibusterGrpcBasicAnalysisConfigurationFile.class;
+    Class<? extends FilibusterAnalysisConfigurationFile> analysisConfigurationFile() default FilibusterDefaultAnalysisConfigurationFile.class;
 }

--- a/src/main/java/cloud/filibuster/junit/configuration/FilibusterAnalysisConfiguration.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/FilibusterAnalysisConfiguration.java
@@ -16,7 +16,15 @@ public class FilibusterAnalysisConfiguration {
     public FilibusterAnalysisConfiguration(Builder builder) {
         this.name = builder.name;
         configurationObject.put("pattern", builder.pattern);
-        configurationObject.put("exceptions", builder.exceptions);
+
+        if (builder.exceptions.size() > 0) {
+            configurationObject.put("exceptions", builder.exceptions);
+        }
+
+        if (builder.errors.size() > 0) {
+            configurationObject.put("errors", builder.errors);
+        }
+
         analysisConfiguration.put(builder.name, configurationObject);
     }
 
@@ -34,6 +42,8 @@ public class FilibusterAnalysisConfiguration {
         private String pattern;
         private final List<JSONObject> exceptions = new ArrayList<>();
 
+        private final List<JSONObject> errors = new ArrayList<>();
+
         @CanIgnoreReturnValue
         public Builder name(String name) {
             this.name = name;
@@ -43,6 +53,15 @@ public class FilibusterAnalysisConfiguration {
         @CanIgnoreReturnValue
         public Builder pattern(String pattern) {
             this.pattern = pattern;
+            return this;
+        }
+
+        @CanIgnoreReturnValue
+        public Builder error(String serviceName, List<JSONObject> types) {
+            JSONObject error = new JSONObject();
+            error.put("service_name", serviceName);
+            error.put("types", types);
+            errors.add(error);
             return this;
         }
 

--- a/src/main/java/cloud/filibuster/junit/configuration/FilibusterDefaultAnalysisConfigurationFile.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/FilibusterDefaultAnalysisConfigurationFile.java
@@ -1,0 +1,106 @@
+package cloud.filibuster.junit.configuration;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FilibusterDefaultAnalysisConfigurationFile implements FilibusterAnalysisConfigurationFile {
+    private static final List<String> exhaustiveGrpcErrorCodeList = new ArrayList<>();
+    private static final FilibusterCustomAnalysisConfigurationFile filibusterCustomAnalysisConfigurationFile;
+
+    private static Map<String, String> createGrpcErrorMap(String code) {
+        Map<String,String> myMap = new HashMap<>();
+        myMap.put("cause", "");
+        myMap.put("code", code);
+        return myMap;
+    }
+
+    private static Map<String, String> createHttpErrorMap(String cause) {
+        Map<String,String> myMap = new HashMap<>();
+        myMap.put("cause", cause);
+        myMap.put("code", "");
+        return myMap;
+    }
+
+    static {
+        FilibusterCustomAnalysisConfigurationFile.Builder filibusterCustomAnalysisConfigurationFileBuilder = new FilibusterCustomAnalysisConfigurationFile.Builder();
+
+        // Google's gRPC exception types.
+        exhaustiveGrpcErrorCodeList.add("DEADLINE_EXCEEDED");
+        exhaustiveGrpcErrorCodeList.add("UNAVAILABLE");
+
+        FilibusterAnalysisConfiguration.Builder filibusterAnalysisConfigurationBuilderGrpcExceptions = new FilibusterAnalysisConfiguration.Builder()
+                .name("java.grpc.exceptions")
+                .pattern("(.*Service/.*)");
+        for (String code : exhaustiveGrpcErrorCodeList) {
+            filibusterAnalysisConfigurationBuilderGrpcExceptions.exception("io.grpc.StatusRuntimeException", createGrpcErrorMap(code));
+        }
+        filibusterCustomAnalysisConfigurationFileBuilder.analysisConfiguration(filibusterAnalysisConfigurationBuilderGrpcExceptions.build());
+
+        // Google's gRPC error types.
+        FilibusterAnalysisConfiguration.Builder filibusterAnalysisConfigurationBuilderGrpcErrors = new FilibusterAnalysisConfiguration.Builder()
+                .name("java.grpc.errors")
+                .pattern("(.*Service/.*)");
+
+        List<String> grpcErrorCodes = new ArrayList<>();
+        grpcErrorCodes.add("UNIMPLEMENTED");
+        grpcErrorCodes.add("INTERNAL");
+
+        List<JSONObject> grpcErrorTypes = new ArrayList<>();
+        for (String errorCode : grpcErrorCodes) {
+            JSONObject codeObject = new JSONObject();
+            codeObject.put("code", errorCode);
+
+            JSONObject metadataObject = new JSONObject();
+            metadataObject.put("metadata", codeObject);
+
+            JSONObject exceptionObject = new JSONObject();
+            exceptionObject.put("exception", metadataObject);
+
+            grpcErrorTypes.add(exceptionObject);
+        }
+
+        filibusterAnalysisConfigurationBuilderGrpcErrors.error(".*", grpcErrorTypes);
+        filibusterCustomAnalysisConfigurationFileBuilder.analysisConfiguration(filibusterAnalysisConfigurationBuilderGrpcErrors.build());
+
+        // Armeria's WebClient exception types.
+        FilibusterAnalysisConfiguration.Builder filibusterAnalysisConfigurationBuilderHttpExceptions = new FilibusterAnalysisConfiguration.Builder()
+                .name("java.WebClient.exceptions")
+                .pattern("WebClient\\.(GET|PUT|POST|HEAD)");
+        filibusterAnalysisConfigurationBuilderHttpExceptions.exception("com.linecorp.armeria.client.UnprocessedRequestException", createHttpErrorMap("io.netty.channel.ConnectTimeoutException"));
+        filibusterCustomAnalysisConfigurationFileBuilder.analysisConfiguration(filibusterAnalysisConfigurationBuilderHttpExceptions.build());
+
+        // Armeria's WebClient error types.
+        FilibusterAnalysisConfiguration.Builder filibusterAnalysisConfigurationBuilderHttpErrors = new FilibusterAnalysisConfiguration.Builder()
+                .name("java.WebClient.errors")
+                .pattern("WebClient\\.(GET|PUT|POST|HEAD)");
+
+        List<String> httpErrorCodes = new ArrayList<>();
+        httpErrorCodes.add("500");
+        httpErrorCodes.add("502");
+        httpErrorCodes.add("503");
+
+        List<JSONObject> webClientErrorTypes = new ArrayList<>();
+        for (String errorCode : httpErrorCodes) {
+            JSONObject statusCodeObject = new JSONObject();
+            statusCodeObject.put("status_code", errorCode);
+
+            JSONObject returnValueObject = new JSONObject();
+            returnValueObject.put("return_value", statusCodeObject);
+
+            webClientErrorTypes.add(returnValueObject);
+        }
+        filibusterAnalysisConfigurationBuilderHttpErrors.error(".*", webClientErrorTypes);
+        filibusterCustomAnalysisConfigurationFileBuilder.analysisConfiguration(filibusterAnalysisConfigurationBuilderHttpErrors.build());
+
+        filibusterCustomAnalysisConfigurationFile = filibusterCustomAnalysisConfigurationFileBuilder.build();
+    }
+
+    @Override
+    public FilibusterCustomAnalysisConfigurationFile toFilibusterCustomAnalysisConfigurationFile() {
+        return filibusterCustomAnalysisConfigurationFile;
+    }
+}

--- a/src/test/java/cloud/filibuster/junit/tests/filibuster/JUnitFilibusterHttpTest.java
+++ b/src/test/java/cloud/filibuster/junit/tests/filibuster/JUnitFilibusterHttpTest.java
@@ -1,0 +1,75 @@
+package cloud.filibuster.junit.tests.filibuster;
+
+import cloud.filibuster.instrumentation.TestHelper;
+import cloud.filibuster.instrumentation.helpers.Networking;
+import cloud.filibuster.junit.FilibusterTest;
+import cloud.filibuster.junit.interceptors.GitHubActionsSkipInvocationInterceptor;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static cloud.filibuster.junit.Assertions.wasFaultInjected;
+import static cloud.filibuster.junit.Assertions.wasFaultInjectedOnService;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class JUnitFilibusterHttpTest extends JUnitBaseTest {
+    private static int numberOfTestsExceptionsThrownFaultsInjected = 0;
+
+    private final List<String> validErrorCodes = Arrays.asList("404", "503");
+
+    /**
+     * Inject faults between Hello and World using Filibuster and assert proper faults are injected.
+     */
+    @DisplayName("Test world route with Filibuster.")
+    @ExtendWith(GitHubActionsSkipInvocationInterceptor.class)
+    @FilibusterTest
+    @Order(1)
+    public void testMyHelloAndMyWorldServiceWithFilibuster() {
+        boolean expected = false;
+
+        try {
+            String baseURI = "http://" + Networking.getHost("hello") + ":" + Networking.getPort("hello") + "/";
+            WebClient webClient = TestHelper.getTestWebClient(baseURI);
+            RequestHeaders getHeaders = RequestHeaders.of(HttpMethod.GET, "/world", HttpHeaderNames.ACCEPT, "application/json");
+            AggregatedHttpResponse response = webClient.execute(getHeaders).aggregate().join();
+            ResponseHeaders headers = response.headers();
+            String statusCode = headers.get(HttpHeaderNames.STATUS);
+
+            if (wasFaultInjected()) {
+                numberOfTestsExceptionsThrownFaultsInjected++;
+                assertTrue(validErrorCodes.contains(statusCode));
+                assertTrue(wasFaultInjectedOnService("world"));
+            } else {
+                assertEquals("200", statusCode);
+            }
+        } catch (Throwable t) {
+            assertFalse(true);
+        }
+    }
+
+    /**
+     * Verify that Filibuster generated the correct number of fault injections.
+     */
+    @DisplayName("Verify correct number of generated Filibuster tests.")
+    @ExtendWith(GitHubActionsSkipInvocationInterceptor.class)
+    @Test
+    @Order(2)
+    public void testNumAssertions() {
+        assertEquals(4, numberOfTestsExceptionsThrownFaultsInjected);
+    }
+}

--- a/src/test/java/cloud/filibuster/junit/tests/filibuster/JUnitFilibusterTest.java
+++ b/src/test/java/cloud/filibuster/junit/tests/filibuster/JUnitFilibusterTest.java
@@ -67,6 +67,14 @@ public class JUnitFilibusterTest extends JUnitBaseTest {
                     expected = true;
                 }
 
+                if (t.getMessage().equals("DATA_LOSS: io.grpc.StatusRuntimeException: UNIMPLEMENTED")) {
+                    expected = true;
+                }
+
+                if (t.getMessage().equals("DATA_LOSS: io.grpc.StatusRuntimeException: INTERNAL")) {
+                    expected = true;
+                }
+
                 boolean wasFaultInjectedOnWorldService = wasFaultInjectedOnService("world");
                 assertTrue(wasFaultInjectedOnWorldService);
 
@@ -93,6 +101,6 @@ public class JUnitFilibusterTest extends JUnitBaseTest {
     @Test
     @Order(2)
     public void testNumAssertions() {
-        assertEquals(2, numberOfTestsExceptionsThrownFaultsInjected);
+        assertEquals(4, numberOfTestsExceptionsThrownFaultsInjected);
     }
 }

--- a/src/test/java/cloud/filibuster/junit/tests/filibuster/JUnitFilibusterTestWithBasicAnalysisFileByAnnotation.java
+++ b/src/test/java/cloud/filibuster/junit/tests/filibuster/JUnitFilibusterTestWithBasicAnalysisFileByAnnotation.java
@@ -29,6 +29,8 @@ public class JUnitFilibusterTestWithBasicAnalysisFileByAnnotation extends JUnitB
     static {
         basicGrpcErrorCodeList.add("DEADLINE_EXCEEDED");
         basicGrpcErrorCodeList.add("UNAVAILABLE");
+        basicGrpcErrorCodeList.add("INTERNAL");
+        basicGrpcErrorCodeList.add("UNIMPLEMENTED");
     }
 
     private static int numberOfTestsExceptionsThrownFaultsInjected = 0;
@@ -78,6 +80,6 @@ public class JUnitFilibusterTestWithBasicAnalysisFileByAnnotation extends JUnitB
     @Test
     @Order(2)
     public void testNumAssertions() {
-        assertEquals(2, numberOfTestsExceptionsThrownFaultsInjected);
+        assertEquals(4, numberOfTestsExceptionsThrownFaultsInjected);
     }
 }

--- a/src/test/java/cloud/filibuster/junit/tests/filibuster/JUnitFilibusterTestWithNoBeforeEachOrAfterEach.java
+++ b/src/test/java/cloud/filibuster/junit/tests/filibuster/JUnitFilibusterTestWithNoBeforeEachOrAfterEach.java
@@ -91,6 +91,14 @@ public class JUnitFilibusterTestWithNoBeforeEachOrAfterEach {
                     expected = true;
                 }
 
+                if (t.getMessage().equals("DATA_LOSS: io.grpc.StatusRuntimeException: INTERNAL")) {
+                    expected = true;
+                }
+
+                if (t.getMessage().equals("DATA_LOSS: io.grpc.StatusRuntimeException: UNIMPLEMENTED")) {
+                    expected = true;
+                }
+
                 if (! expected) {
                     throw t;
                 }
@@ -115,6 +123,6 @@ public class JUnitFilibusterTestWithNoBeforeEachOrAfterEach {
     @Test
     @Order(2)
     public void testNumAssertions() {
-        assertEquals(2, numberOfTestsExceptionsThrownFaultsInjected);
+        assertEquals(4, numberOfTestsExceptionsThrownFaultsInjected);
     }
 }


### PR DESCRIPTION
The default configuration for the Filibuster test annotation did not inject HTTP faults for the Armeria WebClient, so that functionality was added and tests added to ensure the correct operation of that behavior.