### PR TITLE
1.1.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ javadoc {
 
 group = "cloud.filibuster"
 archivesBaseName = "instrumentation"
-version = "1.1.3"
+version = "1.1.4"
 
 java {
     withJavadocJar()

--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ javadoc {
 
 group = "cloud.filibuster"
 archivesBaseName = "instrumentation"
-version = "1.1.4"
+version = "1.1.5"
 
 java {
     withJavadocJar()

--- a/src/main/java/cloud/filibuster/exceptions/filibuster/FilibusterCallsiteGenerationException.java
+++ b/src/main/java/cloud/filibuster/exceptions/filibuster/FilibusterCallsiteGenerationException.java
@@ -1,0 +1,15 @@
+package cloud.filibuster.exceptions.filibuster;
+
+public class FilibusterCallsiteGenerationException extends FilibusterRuntimeException {
+    public FilibusterCallsiteGenerationException(String message) {
+        super(message);
+    }
+
+    public FilibusterCallsiteGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FilibusterCallsiteGenerationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/cloud/filibuster/instrumentation/datatypes/Callsite.java
+++ b/src/main/java/cloud/filibuster/instrumentation/datatypes/Callsite.java
@@ -1,5 +1,6 @@
 package cloud.filibuster.instrumentation.datatypes;
 
+import cloud.filibuster.exceptions.filibuster.FilibusterCallsiteGenerationException;
 import cloud.filibuster.exceptions.filibuster.FilibusterUnknownCallsiteException;
 
 import java.io.BufferedReader;
@@ -264,8 +265,7 @@ public class Callsite {
                         bufferedReader.close();
                     }
                 } catch (IOException e) {
-                    // Nothing right now.
-                    e.printStackTrace();
+                    throw new FilibusterCallsiteGenerationException(e);
                 }
             }
         }

--- a/src/main/java/cloud/filibuster/instrumentation/libraries/grpc/FilibusterClientInterceptor.java
+++ b/src/main/java/cloud/filibuster/instrumentation/libraries/grpc/FilibusterClientInterceptor.java
@@ -382,6 +382,7 @@ public class FilibusterClientInterceptor implements ClientInterceptor {
                 // Notify Filibuster of complete invocation with the proper response.
                 String className = message.getClass().getName();
                 HashMap<String, String> returnValueProperties = new HashMap<>();
+                returnValueProperties.put("toString", message.toString());
                 filibusterClientInstrumentor.afterInvocationComplete(className, returnValueProperties);
 
                 // Delegate.

--- a/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
@@ -108,7 +108,7 @@ public class FilibusterCore {
         String distributedExecutionIndexString = payload.getString("execution_index");
         DistributedExecutionIndex distributedExecutionIndex = new DistributedExecutionIndexV1().deserialize(distributedExecutionIndexString);
         logger.info("[FILIBUSTER-CORE]: beginInvocation called, distributedExecutionIndex: " + distributedExecutionIndex);
-        currentConcreteTestExecution.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, payload);
+        currentConcreteTestExecution.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, payload);
 
         // Get next generated id.
         int generatedId = currentConcreteTestExecution.incrementGeneratedId();

--- a/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
@@ -175,6 +175,10 @@ public class FilibusterCore {
 
         logger.info("[FILIBUSTER-CORE]: endInvocation called, distributedExecutionIndex: " + distributedExecutionIndex);
 
+        if (currentConcreteTestExecution == null) {
+            throw new FilibusterCoreLogicException("currentConcreteTestExecution should not be null at this point, something fatal occurred.");
+        }
+
         JSONObject response = new JSONObject();
         response.put("execution_index", payload.getString("execution_index"));
 

--- a/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
@@ -221,7 +221,7 @@ public class FilibusterCore {
 
         if (currentConcreteTestExecution != null) {
             currentConcreteTestExecution.printRPCs();
-            currentConcreteTestExecution.getTestExecutionReport().writeTestReport();
+            currentConcreteTestExecution.writeTestExecutionReport(currentIteration, /* exceptionOccurred= */ false);
         } else {
             throw new FilibusterCoreLogicException("currentConcreteTestExecution should not be null at this point, something fatal occurred.");
         }
@@ -237,7 +237,7 @@ public class FilibusterCore {
 
         if (currentConcreteTestExecution != null) {
             currentConcreteTestExecution.printRPCs();
-            currentConcreteTestExecution.getTestExecutionReport().writeTestReport();
+            currentConcreteTestExecution.writeTestExecutionReport(currentIteration, /* exceptionOccurred= */ exceptionOccurred != 0);
         } else {
             throw new FilibusterCoreLogicException("currentConcreteTestExecution should not be null at this point, something fatal occurred.");
         }

--- a/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
@@ -179,6 +179,8 @@ public class FilibusterCore {
             throw new FilibusterCoreLogicException("currentConcreteTestExecution should not be null at this point, something fatal occurred.");
         }
 
+        currentConcreteTestExecution.addDistributedExecutionIndexWithResponsePayload(distributedExecutionIndex, payload);
+
         JSONObject response = new JSONObject();
         response.put("execution_index", payload.getString("execution_index"));
 

--- a/src/main/java/cloud/filibuster/junit/server/core/test_execution_reports/MaterializedReportMetadata.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_execution_reports/MaterializedReportMetadata.java
@@ -1,0 +1,27 @@
+package cloud.filibuster.junit.server.core.test_execution_reports;
+
+import org.json.JSONObject;
+
+import java.nio.file.Path;
+
+public class MaterializedReportMetadata {
+    private final int testExecutionNumber;
+
+    private final boolean testExecutionPassed;
+
+    private final Path reportPath;
+
+    public MaterializedReportMetadata(int testExecutionNumber, boolean testExecutionPassed, Path reportPath) {
+        this.testExecutionNumber = testExecutionNumber;
+        this.testExecutionPassed = testExecutionPassed;
+        this.reportPath = reportPath;
+    }
+
+    public JSONObject toJSONObject() {
+        JSONObject result = new JSONObject();
+        result.put("iteration", testExecutionNumber);
+        result.put("status", testExecutionPassed);
+        result.put("path", reportPath.toString());
+        return result;
+    }
+}

--- a/src/main/java/cloud/filibuster/junit/server/core/test_execution_reports/TestExecutionAggregateReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_execution_reports/TestExecutionAggregateReport.java
@@ -1,0 +1,224 @@
+package cloud.filibuster.junit.server.core.test_execution_reports;
+
+import cloud.filibuster.exceptions.filibuster.FilibusterTestReportWriterException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.logging.Logger;
+
+public class TestExecutionAggregateReport {
+    private static final Logger logger = Logger.getLogger(TestExecutionAggregateReport.class.getName());
+
+    private final ArrayList<TestExecutionReport> testExecutionReports = new ArrayList<>();
+
+    public void addTestExecutionReport(TestExecutionReport testExecutionReport) {
+        testExecutionReports.add(testExecutionReport);
+    }
+
+    public void writeOutPlaceholder() {
+        Path directory = Paths.get("/tmp/filibuster");
+        Path indexPath = Paths.get(directory + "/index.html");
+
+        try {
+            Files.createDirectory(directory);
+        } catch(FileAlreadyExistsException e) {
+            // ignored.
+        } catch(IOException e) {
+            throw new FilibusterTestReportWriterException("Filibuster failed to write out the test execution aggregate report: ", e);
+        }
+
+        try {
+            Files.write(indexPath, defaultHtmlContent.getBytes(Charset.defaultCharset()));
+        } catch (IOException e) {
+            throw new FilibusterTestReportWriterException("Filibuster failed to write out the test execution aggregate report: ", e);
+        }
+    }
+
+    private static final String defaultHtmlContent = "<html lang=\"en\">\n" +
+            "\n" +
+            "<head>\n" +
+            "    <meta charset=\"UTF-8\">\n" +
+            "    <title>Filibuster Test Execution Report</title>\n" +
+            "</head>\n" +
+            "<body>\n" +
+            "\n" +
+            "    <div style=\"margin: 0 auto; width: 100px;\">\n" +
+            "        Please wait...\n" +
+            "    </div>\n" +
+            "\n" +
+            "</body>\n" +
+            "</html>";
+
+    public void writeTestExecutionAggregateReport() {
+        Path directory = Paths.get("/tmp/filibuster/");
+
+        try {
+            Files.createDirectory(directory);
+        } catch(FileAlreadyExistsException e) {
+            // Ignore.
+        } catch (IOException e) {
+            throw new FilibusterTestReportWriterException("Filibuster failed to write out the test execution aggregate report: ", e);
+        }
+
+        // Write out the actual JSON data.
+        Path scriptFile = Paths.get(directory + "/analysis.js");
+        try {
+            Files.write(scriptFile, toJavascript().getBytes(Charset.defaultCharset()));
+        } catch (IOException e) {
+            throw new FilibusterTestReportWriterException("Filibuster failed to write out the test execution aggregate report: ", e);
+        }
+
+        // Write out index file.
+        Path indexPath = Paths.get(directory + "/index.html");
+        try {
+            Files.write(indexPath, htmlContent.getBytes(Charset.defaultCharset()));
+        } catch (IOException e) {
+            throw new FilibusterTestReportWriterException("Filibuster failed to write out the test execution aggregate report: ", e);
+        }
+
+        logger.info(
+                "" + "\n" +
+                        "[FILIBUSTER-CORE]: Test Execution Report written to file://" + indexPath + "\n");
+    }
+
+    private JSONObject toJSONObject() {
+        JSONObject result = new JSONObject();
+        ArrayList<JSONObject> materializedReportMetadatas = new ArrayList<>();
+
+        for (TestExecutionReport ter : testExecutionReports) {
+            MaterializedReportMetadata mrm = ter.getMaterializedReportMetadata();
+
+            if (mrm != null) {
+                materializedReportMetadatas.add(ter.getMaterializedReportMetadata().toJSONObject());
+            }
+        }
+
+        result.put("reports", materializedReportMetadatas);
+        return result;
+    }
+
+    private String toJavascript() {
+        JSONObject jsonObject = toJSONObject();
+        return "var analysis = " + jsonObject.toString(4) + ";";
+    }
+
+    private static final String htmlContent = "<html lang=\"en\">\n" +
+            "\n" +
+            "<head>\n" +
+            "    <meta charset=\"UTF-8\">\n" +
+            "    <title>Filibuster Test Execution Report</title>\n" +
+            "    <script src=\"https://code.jquery.com/jquery-3.5.1.js\"></script>\n" +
+            "    <script type=\"text/javascript\" src=\"./analysis.js\"></script>\n" +
+            "    <style>\n" +
+            "\t\ttable {\n" +
+            "\t\t\tmargin: 0 auto;\n" +
+            "\t\t\tfont-size: large;\n" +
+            "\t\t\tborder: 1px solid black;\n" +
+            "            table-layout: fixed;\n" +
+            "\t\t}\n" +
+            "\n" +
+            "\t\th1 {\n" +
+            "\t\t\ttext-align: center;\n" +
+            "\t\t\tcolor: #006600;\n" +
+            "\t\t\tfont-size: xx-large;\n" +
+            "\t\t\tfont-family: 'Gill Sans',\n" +
+            "\t\t\t\t'Gill Sans MT', ' Calibri',\n" +
+            "\t\t\t\t'Trebuchet MS', 'sans-serif';\n" +
+            "\t\t}\n" +
+            "\n" +
+            "        div {\n" +
+            "\t\t\ttext-align: center;\n" +
+            "            margin: 0 auto;\n" +
+            "            width: 500px;\n" +
+            "            padding-bottom: 10px;\n" +
+            "        }\n" +
+            "\n" +
+            "        .fail { \n" +
+            "            font-weight: bold;\n" +
+            "            color: red;\n" +
+            "        }\n" +
+            "\n" +
+            "        .pass { \n" +
+            "            font-weight: bold;\n" +
+            "            color: green;\n" +
+            "        }\n" +
+            "\n" +
+            "\t\ttd {\n" +
+            "\t\t\tborder: 1px solid black;\n" +
+            "\t\t}\n" +
+            "\n" +
+            "\t\tth,\n" +
+            "\t\ttd {\n" +
+            "\t\t\tfont-weight: bold;\n" +
+            "\t\t\tborder: 1px solid black;\n" +
+            "\t\t\tpadding: 10px;\n" +
+            "\t\t\ttext-align: center;\n" +
+            "\t\t}\n" +
+            "\n" +
+            "\t\ttd {\n" +
+            "            font-weight: lighter;\n" +
+            "\t\t}\n" +
+            "\n" +
+            "        tr.success {\n" +
+            "            background-color: green;\n" +
+            "        }\n" +
+            "\n" +
+            "        tr.exception {\n" +
+            "            background-color: yellow;\n" +
+            "        }\n" +
+            "\n" +
+            "        tr.fault {\n" +
+            "            background-color: red;\n" +
+            "        }\n" +
+            "\t</style>\n" +
+            "</head>\n" +
+            "\n" +
+            "<body>\n" +
+            "<section>\n" +
+            "    <h1>Filibuster Test Execution Report</h1>\n" +
+            "\n" +
+            "    <div id='status'></div>\n" +
+            "\n" +
+            "    <table id='table'>\n" +
+            "        <tr>\n" +
+            "            <th>Test Execution</th>\n" +
+            "            <th>Status</th>\n" +
+            "            <th>Link</th>\n" +
+            "        </tr>\n" +
+            "\n" +
+            "        <script>\n" +
+            "\t\t\t\t$(document).ready(function () {\n" +
+            "                    console.log(analysis);\n" +
+            "\n" +
+            "                    for (i in analysis.reports) {\n" +
+            "                        var row = '';\n" +
+            "                        var report = analysis.reports[i];\n" +
+            "                        var statusText = '';\n" +
+            "\n" +
+            "                        if (report.status == true) {\n" +
+            "                            statusText = '<font style=\"color: green\">Passed</font>';\n" +
+            "                        } else {\n" +
+            "                            statusText = '<font style=\"color: red\">Failed</font>';\n" +
+            "                        }\n" +
+            "\n" +
+            "                        row += '<tr>';\n" +
+            "                        row += '<td>' + report.iteration + '</td>';\n" +
+            "                        row += '<td>' + statusText + '</td>';\n" +
+            "                        row += '<td><a href=\"' + report.path + '\">Link To Report</a></td>';\n" +
+            "                        row += '</tr>';\n" +
+            "\n" +
+            "\t\t\t\t\t\t$('#table').append(row);\n" +
+            "                    }\n" +
+            "\t\t\t\t});\n" +
+            "\t\t\t</script>\n" +
+            "</section>\n" +
+            "</body>\n" +
+            "\n" +
+            "</html>\n";
+}

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/ConcreteTestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/ConcreteTestExecution.java
@@ -28,6 +28,12 @@ public class ConcreteTestExecution extends TestExecution implements Cloneable {
         return testExecutionReport;
     }
 
+    public void writeTestExecutionReport(int currentIteration, boolean exceptionOccurred) {
+        if (testExecutionReport != null) {
+            testExecutionReport.writeTestReport(currentIteration, exceptionOccurred);
+        }
+    }
+
     @Override
     protected Object clone() {
         ConcreteTestExecution concreteTestExecution = new ConcreteTestExecution();

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/ConcreteTestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/ConcreteTestExecution.java
@@ -3,19 +3,12 @@ package cloud.filibuster.junit.server.core.test_executions;
 import cloud.filibuster.dei.DistributedExecutionIndex;
 import org.json.JSONObject;
 
-import java.util.Map;
-
 @SuppressWarnings("Varifier")
 public class ConcreteTestExecution extends TestExecution implements Cloneable {
     private final TestExecutionReport testExecutionReport = new TestExecutionReport();
 
     public ConcreteTestExecution() {
 
-    }
-
-    public void addDistributedExecutionIndexWithPayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload) {
-        testExecutionReport.recordInvocation(distributedExecutionIndex, payload);
-        super.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, payload);
     }
 
     public ConcreteTestExecution(AbstractTestExecution abstractTestExecution) {
@@ -31,6 +24,10 @@ public class ConcreteTestExecution extends TestExecution implements Cloneable {
         return abstractTestExecution;
     }
 
+    public TestExecutionReport getTestExecutionReport() {
+        return testExecutionReport;
+    }
+
     @Override
     protected Object clone() {
         ConcreteTestExecution concreteTestExecution = new ConcreteTestExecution();
@@ -42,7 +39,15 @@ public class ConcreteTestExecution extends TestExecution implements Cloneable {
         return concreteTestExecution;
     }
 
-    public TestExecutionReport getTestExecutionReport() {
-        return testExecutionReport;
+    @Override
+    public void addDistributedExecutionIndexWithRequestPayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload) {
+        testExecutionReport.recordInvocation(distributedExecutionIndex, payload);
+        super.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, payload);
+    }
+
+    @Override
+    public void addDistributedExecutionIndexWithResponsePayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload) {
+        testExecutionReport.recordInvocationComplete(distributedExecutionIndex, payload);
+        super.addDistributedExecutionIndexWithResponsePayload(distributedExecutionIndex, payload);
     }
 }

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/ConcreteTestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/ConcreteTestExecution.java
@@ -1,6 +1,7 @@
 package cloud.filibuster.junit.server.core.test_executions;
 
 import cloud.filibuster.dei.DistributedExecutionIndex;
+import cloud.filibuster.junit.server.core.test_execution_reports.TestExecutionReport;
 import org.json.JSONObject;
 
 @SuppressWarnings("Varifier")

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
@@ -14,7 +14,7 @@ public abstract class TestExecution {
     private static final Logger logger = Logger.getLogger(TestExecution.class.getName());
 
     // Legacy value used to number the RPCs for fault injection.
-    // Superceded by DistributedExecutionIndex, but kept in for compatibility and debugging.
+    // Superseded by DistributedExecutionIndex, but kept in for compatibility and debugging.
     int generatedId = 0;
 
     // What RPCs were executed?
@@ -72,9 +72,8 @@ public abstract class TestExecution {
         executedRPCs.put(distributedExecutionIndex, payloadWithoutInstrumentationType);
 
         // Add to the list of nondeterministic executed RPCs.
-        JSONObject nondeterministicPayload = new JSONObject(payload.toString());
-        nondeterministicPayload.remove("args");
-        nondeterministicExecutedRPCs.put(distributedExecutionIndex, nondeterministicPayload);
+        JSONObject deterministicPayload = cleanPayloadOfArguments(payload);
+        nondeterministicExecutedRPCs.put(distributedExecutionIndex, deterministicPayload);
     }
 
     public int incrementGeneratedId() {
@@ -212,6 +211,12 @@ public abstract class TestExecution {
     private static JSONObject cleanPayloadOfInstrumentationType(JSONObject payload) {
         JSONObject jsonObject = new JSONObject(payload.toString());
         jsonObject.remove("instrumentation_type");
+        return jsonObject;
+    }
+
+    private static JSONObject cleanPayloadOfArguments(JSONObject payload) {
+        JSONObject jsonObject = new JSONObject(payload.toString());
+        jsonObject.remove("args");
         return jsonObject;
     }
 }

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
@@ -66,7 +66,7 @@ public abstract class TestExecution {
         }
     }
 
-    public void addDistributedExecutionIndexWithPayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload) {
+    public void addDistributedExecutionIndexWithRequestPayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload) {
         // Add to the list of executed RPCs.
         JSONObject payloadWithoutInstrumentationType = cleanPayloadOfInstrumentationType(payload);
         executedRPCs.put(distributedExecutionIndex, payloadWithoutInstrumentationType);

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
@@ -76,6 +76,10 @@ public abstract class TestExecution {
         nondeterministicExecutedRPCs.put(distributedExecutionIndex, deterministicPayload);
     }
 
+    public void addDistributedExecutionIndexWithResponsePayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload) {
+        // Nothing for now.
+    }
+
     public int incrementGeneratedId() {
         // Increment the generated_id; not used for anything anymore and merely here for debugging and because callers require it.
         generatedId++;

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
@@ -57,7 +57,10 @@ public abstract class TestExecution {
             for (DistributedExecutionIndex name: faultsToInject.keySet()) {
                 String key = name.toString();
                 JSONObject value = faultsToInject.get(name);
-                JSONObject request = executedRPCs.getOrDefault(name, new JSONObject().put("error", "no request information found")); // eventually remove this. // TODO: needed anymore????
+
+                // getOrDefault needed because when application is nondeterministic the lookup for the request will fail because of a lack of DEI matches.
+                JSONObject request = executedRPCs.getOrDefault(name, new JSONObject().put("error", "no request information found"));
+
                 logMessage.append(key).append(" => ").append(value.toString(4)).append(" => ").append(request.toString(4)).append("\n");
             }
         } else {

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
@@ -67,10 +67,9 @@ public abstract class TestExecution {
     }
 
     public void addDistributedExecutionIndexWithPayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload) {
-        cleanPayload(payload);
-
         // Add to the list of executed RPCs.
-        executedRPCs.put(distributedExecutionIndex, payload);
+        JSONObject payloadWithoutInstrumentationType = cleanPayloadOfInstrumentationType(payload);
+        executedRPCs.put(distributedExecutionIndex, payloadWithoutInstrumentationType);
 
         // Add to the list of nondeterministic executed RPCs.
         JSONObject nondeterministicPayload = new JSONObject(payload.toString());
@@ -210,8 +209,9 @@ public abstract class TestExecution {
         return false;
     }
 
-    private static void cleanPayload(JSONObject payload) {
-        // Remove fields that are only related to the logging and don't contain useful information.
-        payload.remove("instrumentation_type");
+    private static JSONObject cleanPayloadOfInstrumentationType(JSONObject payload) {
+        JSONObject jsonObject = new JSONObject(payload.toString());
+        jsonObject.remove("instrumentation_type");
+        return jsonObject;
     }
 }

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
@@ -37,33 +37,35 @@ public abstract class TestExecution {
     }
 
     public void printRPCs() {
-        logger.info("RPCs executed and interposed by Filibuster:");
+        StringBuilder logMessage = new StringBuilder("\n");
+
+        logMessage.append("[FILIBUSTER-CORE]: RPCs executed and interposed by Filibuster");
+        logMessage.append("\n").append("\n");
 
         for (DistributedExecutionIndex name: executedRPCs.keySet()) {
             String key = name.toString();
             JSONObject value = executedRPCs.get(name);
             if (key != null && value != null) {
-                logger.info("\n" +
-                        "distributedExecutionIndex: " + key + "\n" +
-                        "payload: " + value.toString(4));
+                logMessage.append(key).append(" => ").append(value.toString(4)).append("\n");
             }
         }
 
         if (!faultsToInject.isEmpty()) {
-            logger.info("Faults injected by Filibuster (" + faultsToInject.size() + "): ");
+            logMessage.append("[FILIBUSTER-CORE]: Faults injected by Filibuster");
+            logMessage.append("\n").append("\n");
 
             for (DistributedExecutionIndex name: faultsToInject.keySet()) {
                 String key = name.toString();
                 JSONObject value = faultsToInject.get(name);
-                JSONObject request = executedRPCs.getOrDefault(name, new JSONObject().put("error", "no request information found")); // eventually remove this.
-                logger.info("\n" +
-                        "distributedExecutionIndex: " + key + "\n" +
-                        "payload: " + value.toString(4) + "\n" +
-                        "request: " + request.toString(4));
+                JSONObject request = executedRPCs.getOrDefault(name, new JSONObject().put("error", "no request information found")); // eventually remove this. // TODO: needed anymore????
+                logMessage.append(key).append(" => ").append(value.toString(4)).append(" => ").append(request.toString(4)).append("\n");
             }
         } else {
-            logger.info("No faults injected by Filibuster:");
+            logMessage.append("[FILIBUSTER-CORE]: No faults injected by Filibuster.");
+            logMessage.append("\n").append("\n");
         }
+
+        logger.info(logMessage.toString());
     }
 
     public void addDistributedExecutionIndexWithRequestPayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload) {

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
@@ -147,6 +147,10 @@ public class TestExecutionReport {
             "            background-color: green;\n" +
             "        }\n" +
             "\n" +
+            "        tr.exception {\n" +
+            "            background-color: yellow;\n" +
+            "        }\n" +
+            "\n" +
             "        tr.fault {\n" +
             "            background-color: red;\n" +
             "        }\n" +
@@ -162,7 +166,8 @@ public class TestExecutionReport {
             "            <th>Distributed Execution Index</th>\n" +
             "            <th>RPC Method</th>\n" +
             "            <th>RPC Arguments</th>\n" +
-            "            <th>Fault</th>\n" +
+            "            <th>Response</th>\n" +
+            "            <th>Fault?</th>\n" +
             "        </tr>\n" +
             "\n" +
             "        <script>\n" +
@@ -170,13 +175,16 @@ public class TestExecutionReport {
             "                    return Object.keys(obj).length === 0;\n" +
             "                }\n" +
             "\n" +
+            "                function containsExceptionKey(obj) {\n" +
+            "                    return \"exception\" in obj;\n" +
+            "                }\n" +
+            "\n" +
             "\t\t\t\t$(document).ready(function () {\n" +
             "                    for (i in analysis.rpcs) {\n" +
             "                        var rpc = analysis.rpcs[i];\n" +
             "                        var isFaulted = !isEmpty(rpc.fault);\n" +
-            "                        console.log(rpc);\n" +
-            "                        console.log(rpc.fault);\n" +
-            "                        console.log(isEmpty(rpc.fault));\n" +
+            "                        var isExceptionResponse = containsExceptionKey(rpc.response);\n" +
+            "                        console.log(rpc.response);\n" +
             "\n" +
             "                        var row = '';\n" +
             "\n" +

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.logging.Logger;
@@ -100,8 +99,6 @@ public class TestExecutionReport {
             throw new FilibusterTestReportWriterException(e);
         }
     }
-
-    private static final SecureRandom random = new SecureRandom();
 
     private String htmlContent = "<html lang=\"en\">\n" +
             "\n" +

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
@@ -212,7 +212,7 @@ public class TestExecutionReport {
             "                            }\n" +
             "                            row += '</td>';\n" +
             "                        } else {\n" +
-            "                            row += '<td class=\"response\">' + rpc.response.return_value.__class__ + '</td>';\n" +
+            "                            row += '<td class=\"response\"><textarea>' + rpc.response.return_value.toString + '</textarea></td>';\n" +
             "                        }\n" +
             "\n" +
             "                        if (!isFaulted) {\n" +

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
@@ -103,18 +103,6 @@ public class TestExecutionReport {
 
     private static final SecureRandom random = new SecureRandom();
 
-    private static String generateFilename() {
-        long n = random.nextLong();
-
-        if (n == Long.MIN_VALUE) {
-            n = 0;
-        } else {
-            n = Math.abs(n);
-        }
-
-        return "filibuster-test-execution-report-" + n;
-    }
-
     private String htmlContent = "<html lang=\"en\">\n" +
             "\n" +
             "<head>\n" +

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
@@ -189,19 +189,43 @@ public class TestExecutionReport {
             "                        var row = '';\n" +
             "\n" +
             "                        if (!isFaulted) {\n" +
-            "                            row += '<tr class=\"success\">';\n" +
+            "                            if (isExceptionResponse) {\n" +
+            "                                row += '<tr class=\"exception\">';\n" +
+            "                            } else {\n" +
+            "                                row += '<tr class=\"success\">';\n" +
+            "                            }\n" +
             "                        } else {\n" +
             "                            row += '<tr class=\"fault\">';\n" +
             "                        }\n" +
             "\n" +
             "                        row += '<td class=\"dei\"><textarea>' + rpc.dei + '</textarea></td>';\n" +
-            "                        row += '<td class=\"method\">' + rpc.details.method + '</td>';\n" +
-            "                        row += '<td class=\"args\"><textarea>' + rpc.details.args + '</textarea></td>';\n" +
+            "                        row += '<td class=\"method\">' + rpc.request.method + '</td>';\n" +
+            "                        row += '<td class=\"args\"><textarea>' + rpc.request.args + '</textarea></td>';\n" +
+            "\n" +
+            "                        if (isExceptionResponse) {\n" +
+            "                            row += '<td>';\n" +
+            "                            row += 'code = ' + rpc.response.exception.metadata.code + ', ';\n" +
+            "                            if (rpc.response.exception.metadata.cause === \"\") {\n" +
+            "                                row += 'cause = undefined';\n" +
+            "                            } else {\n" +
+            "                                row += 'cause = ' + rpc.response.exception.metadata.cause;\n" +
+            "                            }\n" +
+            "                            row += '</td>';\n" +
+            "                        } else {\n" +
+            "                            row += '<td class=\"response\">' + rpc.response.return_value.__class__ + '</td>';\n" +
+            "                        }\n" +
             "\n" +
             "                        if (!isFaulted) {\n" +
             "                            row += '<td></td>';\n" +
             "                        } else {\n" +
-            "                            row += '<td>' + rpc.fault.forced_exception.metadata.code + '</td>';\n" +
+            "                            row += '<td>';\n" +
+            "                            row += 'code = ' + rpc.fault.forced_exception.metadata.code + ', ';\n" +
+            "                            if (rpc.fault.forced_exception.metadata.cause === \"\") {\n" +
+            "                                row += 'cause = null';\n" +
+            "                            } else {\n" +
+            "                                row += 'cause = ' + rpc.fault.forced_exception.metadata.cause;\n" +
+            "                            }\n" +
+            "                            row += '</td>';\n" +
             "                        }\n" +
             "\n" +
             "                        row += '</tr>';\n" +

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
@@ -99,7 +99,7 @@ public class TestExecutionReport {
         }
     }
 
-    private String htmlContent = "<html lang=\"en\">\n" +
+    private static final String htmlContent = "<html lang=\"en\">\n" +
             "\n" +
             "<head>\n" +
             "    <meta charset=\"UTF-8\">\n" +

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
@@ -5,6 +5,7 @@ import cloud.filibuster.exceptions.filibuster.FilibusterTestReportWriterExceptio
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -85,11 +86,11 @@ public class TestExecutionReport {
 
             // Write out the actual JSON report.
             Path scriptFile = Files.createFile(Paths.get(directory.toString() + "/analysis.js"));
-            Files.write(scriptFile, toJavascript().getBytes());
+            Files.write(scriptFile, toJavascript().getBytes(Charset.defaultCharset()));
 
             // Copy index file over.
             Path indexPath = Paths.get(directory + "/index.html");
-            Files.write(indexPath, htmlContent.getBytes());
+            Files.write(indexPath, htmlContent.getBytes(Charset.defaultCharset()));
 
             logger.info(
                     "" + "\n" +

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
@@ -47,12 +47,11 @@ public class TestExecutionReport {
     }
 
     static class Keys {
-        private static String DEI_KEY = "dei";
-        private static String REQUEST_KEY = "request";
-        private static String RESPONSE_KEY = "response";
-        private static String FAULT_KEY = "fault";
-        private static String RPCS_KEY = "rpcs";
-        private static String PASSED_KEY = "passed";
+        private static final String DEI_KEY = "dei";
+        private static final String REQUEST_KEY = "request";
+        private static final String RESPONSE_KEY = "response";
+        private static final String FAULT_KEY = "fault";
+        private static final String RPCS_KEY = "rpcs";
     }
 
     @SuppressWarnings("MemberName")

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
@@ -49,7 +49,8 @@ public class TestExecutionReport {
 
     static class Keys {
         private static String DEI_KEY = "dei";
-        private static String DETAILS_KEY = "details";
+        private static String REQUEST_KEY = "request";
+        private static String RESPONSE_KEY = "response";
         private static String FAULT_KEY = "fault";
         private static String RPCS_KEY = "rpcs";
         private static String PASSED_KEY = "passed";
@@ -62,7 +63,8 @@ public class TestExecutionReport {
         for (DistributedExecutionIndex dei : deiInvocationOrder) {
             JSONObject RPC = new JSONObject();
             RPC.put(Keys.DEI_KEY, dei.toString());
-            RPC.put(Keys.DETAILS_KEY, deiInvocations.getOrDefault(dei, new JSONObject()));
+            RPC.put(Keys.REQUEST_KEY, deiInvocations.getOrDefault(dei, new JSONObject()));
+            RPC.put(Keys.RESPONSE_KEY, deiResponses.getOrDefault(dei, new JSONObject()));
             RPC.put(Keys.FAULT_KEY, deiFaultsInjected.getOrDefault(dei, new JSONObject()));
             RPCs.add(RPC);
         }

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecutionReport.java
@@ -20,6 +20,8 @@ public class TestExecutionReport {
 
     private final HashMap<DistributedExecutionIndex, JSONObject> deiInvocations = new HashMap<>();
 
+    private final HashMap<DistributedExecutionIndex, JSONObject> deiResponses = new HashMap<>();
+
     private final HashMap<DistributedExecutionIndex, JSONObject> deiFaultsInjected = new HashMap<>();
 
     public void recordInvocation(
@@ -31,6 +33,14 @@ public class TestExecutionReport {
 
         // ...then, record the information about the invocation.
         deiInvocations.put(distributedExecutionIndex, invocationJsonObject);
+    }
+
+    public void recordInvocationComplete(
+            DistributedExecutionIndex distributedExecutionIndex,
+            JSONObject invocationJsonObject
+    ) {
+        // Record the information about the invocation's response.
+        deiResponses.put(distributedExecutionIndex, invocationJsonObject);
     }
 
     public void setFaultsInjected(HashMap<DistributedExecutionIndex, JSONObject> faultsToInject) {

--- a/src/main/proto/hello.proto
+++ b/src/main/proto/hello.proto
@@ -15,7 +15,7 @@ service HelloService {
   rpc LotsOfReplies (HelloRequest) returns (stream HelloReply) {}
   rpc LotsOfGreetings (stream HelloRequest) returns (HelloReply) {}
   rpc BidiHello (stream HelloRequest) returns (stream HelloReply) {}
-  rpc Unavailable (HelloRequest) returns (HelloReply) {}
+  rpc Unimplemented (HelloRequest) returns (HelloReply) {}
 }
 
 message HelloRequest {
@@ -28,7 +28,7 @@ message HelloReply {
 
 service WorldService {
   rpc World (WorldRequest) returns (WorldReply) {}
-  rpc WorldUnavailable (WorldRequest) returns (WorldReply) {}
+  rpc WorldUnimplemented (WorldRequest) returns (WorldReply) {}
   rpc WorldExternalHttp (WorldRequest) returns (WorldReply) {}
   rpc WorldExternalGrpc (WorldRequest) returns (WorldReply) {}
 }

--- a/src/test/java/cloud/filibuster/functional/java/basic/JUnitFilibusterTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/basic/JUnitFilibusterTest.java
@@ -55,6 +55,8 @@ public class JUnitFilibusterTest extends JUnitBaseTest {
             assertEquals("Hello, Armerian World!!", reply.getMessage());
             assertFalse(wasFaultInjected());
         } catch (Throwable t) {
+            assertEquals(false, true);
+
             boolean wasFaultInjected = wasFaultInjected();
 
             if (wasFaultInjected) {

--- a/src/test/java/cloud/filibuster/functional/java/basic/JUnitFilibusterTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/basic/JUnitFilibusterTest.java
@@ -55,8 +55,6 @@ public class JUnitFilibusterTest extends JUnitBaseTest {
             assertEquals("Hello, Armerian World!!", reply.getMessage());
             assertFalse(wasFaultInjected());
         } catch (Throwable t) {
-            assertEquals(false, true);
-
             boolean wasFaultInjected = wasFaultInjected();
 
             if (wasFaultInjected) {

--- a/src/test/java/cloud/filibuster/functional/java/basic/JUnitFilibusterUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/basic/JUnitFilibusterUnimplementedTest.java
@@ -1,11 +1,12 @@
-package cloud.filibuster.functional.python.basic;
+package cloud.filibuster.functional.java.basic;
 
 import cloud.filibuster.examples.Hello;
+import cloud.filibuster.examples.Hello.HelloRequest;
 import cloud.filibuster.examples.HelloServiceGrpc;
+import cloud.filibuster.examples.HelloServiceGrpc.HelloServiceBlockingStub;
 import cloud.filibuster.instrumentation.helpers.Networking;
 import cloud.filibuster.junit.FilibusterTest;
-import cloud.filibuster.junit.interceptors.GitHubActionsSkipInvocationInterceptor;
-import cloud.filibuster.junit.server.backends.FilibusterLocalProcessServerBackend;
+import cloud.filibuster.junit.server.backends.FilibusterLocalServerBackend;
 import cloud.filibuster.functional.JUnitBaseTest;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -15,7 +16,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -28,12 +28,11 @@ import static org.testcontainers.shaded.org.hamcrest.MatcherAssert.assertThat;
 import static org.testcontainers.shaded.org.hamcrest.Matchers.containsString;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class JUnitFilibusterUnavailableTest extends JUnitBaseTest {
+public class JUnitFilibusterUnimplementedTest extends JUnitBaseTest {
     private final static Set<String> testExceptionsThrown = new HashSet<>();
 
     @DisplayName("Test partial hello server grpc route with Filibuster. (MyHelloService, MyWorldService)")
-    @ExtendWith(GitHubActionsSkipInvocationInterceptor.class)
-    @FilibusterTest(serverBackend=FilibusterLocalProcessServerBackend.class)
+    @FilibusterTest(serverBackend=FilibusterLocalServerBackend.class)
     @Order(1)
     public void testMyHelloAndMyWorldServiceWithFilibuster() throws InterruptedException {
         ManagedChannel helloChannel = ManagedChannelBuilder
@@ -42,9 +41,9 @@ public class JUnitFilibusterUnavailableTest extends JUnitBaseTest {
                 .build();
 
         try {
-            HelloServiceGrpc.HelloServiceBlockingStub blockingStub = HelloServiceGrpc.newBlockingStub(helloChannel);
-            Hello.HelloRequest request = Hello.HelloRequest.newBuilder().setName("Armerian").build();
-            blockingStub.unavailable(request);
+            HelloServiceBlockingStub blockingStub = HelloServiceGrpc.newBlockingStub(helloChannel);
+            HelloRequest request = HelloRequest.newBuilder().setName("Armerian").build();
+            blockingStub.unimplemented(request);
             assertTrue(false);
         } catch (StatusRuntimeException e) {
             if (wasFaultInjected()) {
@@ -64,7 +63,6 @@ public class JUnitFilibusterUnavailableTest extends JUnitBaseTest {
      * Verify that Filibuster generated the correct number of fault injections.
      */
     @DisplayName("Verify correct number of generated Filibuster tests.")
-    @ExtendWith(GitHubActionsSkipInvocationInterceptor.class)
     @Test
     @Order(2)
     public void testNumAssertions() {

--- a/src/test/java/cloud/filibuster/functional/java/basic/JUnitFilibusterUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/basic/JUnitFilibusterUnimplementedTest.java
@@ -1,6 +1,5 @@
 package cloud.filibuster.functional.java.basic;
 
-import cloud.filibuster.examples.Hello;
 import cloud.filibuster.examples.Hello.HelloRequest;
 import cloud.filibuster.examples.HelloServiceGrpc;
 import cloud.filibuster.examples.HelloServiceGrpc.HelloServiceBlockingStub;

--- a/src/test/java/cloud/filibuster/functional/java/basic/JUnitFilibusterUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/basic/JUnitFilibusterUnimplementedTest.java
@@ -51,7 +51,7 @@ public class JUnitFilibusterUnimplementedTest extends JUnitBaseTest {
                 assertThat(e.getMessage(), containsString("DATA_LOSS: io.grpc.StatusRuntimeException:"));
             } else {
                 // Actual response when the remote service is online but unimplemented.
-                assertEquals("DATA_LOSS: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method cloud.filibuster.examples.WorldService/WorldUnavailable is unimplemented", e.getMessage());
+                assertEquals("DATA_LOSS: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method cloud.filibuster.examples.WorldService/WorldUnimplemented is unimplemented", e.getMessage());
             }
         }
 

--- a/src/test/java/cloud/filibuster/functional/java/bfs/JUnitFilibusterHelloUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/bfs/JUnitFilibusterHelloUnimplementedTest.java
@@ -103,7 +103,7 @@ public class JUnitFilibusterHelloUnimplementedTest extends JUnitBaseTest {
                     throw t;
                 }
             } else {
-                if (t.getMessage().equals("DATA_LOSS: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method cloud.filibuster.examples.WorldService/WorldUnavailable is unimplemented")) {
+                if (t.getMessage().equals("DATA_LOSS: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method cloud.filibuster.examples.WorldService/WorldUnimplemented is unimplemented")) {
                     expected = true;
                 }
 

--- a/src/test/java/cloud/filibuster/functional/java/bfs/JUnitFilibusterHelloUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/bfs/JUnitFilibusterHelloUnimplementedTest.java
@@ -1,6 +1,5 @@
 package cloud.filibuster.functional.java.bfs;
 
-import cloud.filibuster.examples.Hello;
 import cloud.filibuster.examples.Hello.HelloReply;
 import cloud.filibuster.examples.Hello.HelloRequest;
 import cloud.filibuster.examples.HelloServiceGrpc;

--- a/src/test/java/cloud/filibuster/functional/java/bfs/JUnitFilibusterHelloUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/bfs/JUnitFilibusterHelloUnimplementedTest.java
@@ -1,11 +1,15 @@
-package cloud.filibuster.functional.java_hello;
+package cloud.filibuster.functional.java.bfs;
 
 import cloud.filibuster.examples.Hello;
+import cloud.filibuster.examples.Hello.HelloReply;
+import cloud.filibuster.examples.Hello.HelloRequest;
 import cloud.filibuster.examples.HelloServiceGrpc;
+import cloud.filibuster.examples.HelloServiceGrpc.HelloServiceBlockingStub;
+import cloud.filibuster.functional.JUnitBaseTest;
 import cloud.filibuster.instrumentation.helpers.Networking;
+import cloud.filibuster.junit.FilibusterSearchStrategy;
 import cloud.filibuster.junit.FilibusterTest;
 import cloud.filibuster.junit.server.backends.FilibusterLocalServerBackend;
-import cloud.filibuster.functional.JUnitBaseTest;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import org.junit.jupiter.api.DisplayName;
@@ -31,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Test simple annotation usage.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class JUnitFilibusterHelloUnavailableTest extends JUnitBaseTest {
+public class JUnitFilibusterHelloUnimplementedTest extends JUnitBaseTest {
     private final static Set<String> testExceptionsThrown = new HashSet<>();
 
     private static int numberOfTestsExecuted = 0;
@@ -39,7 +43,7 @@ public class JUnitFilibusterHelloUnavailableTest extends JUnitBaseTest {
     private static int numberOfExceptionsThrown = 0;
 
     @DisplayName("Test partial hello server grpc route with Filibuster. (MyHelloService, MyWorldService)")
-    @FilibusterTest(serverBackend=FilibusterLocalServerBackend.class, maxIterations=10)
+    @FilibusterTest(serverBackend=FilibusterLocalServerBackend.class, searchStrategy= FilibusterSearchStrategy.BFS, maxIterations=10)
     @Order(1)
     public void testMyHelloAndMyWorldServiceWithFilibuster() throws InterruptedException {
         ManagedChannel helloChannel = ManagedChannelBuilder
@@ -51,11 +55,11 @@ public class JUnitFilibusterHelloUnavailableTest extends JUnitBaseTest {
 
         numberOfTestsExecuted++;
 
-        HelloServiceGrpc.HelloServiceBlockingStub blockingStub = HelloServiceGrpc.newBlockingStub(helloChannel);
-        Hello.HelloRequest request = Hello.HelloRequest.newBuilder().setName("Armerian").build();
+        HelloServiceBlockingStub blockingStub = HelloServiceGrpc.newBlockingStub(helloChannel);
+        HelloRequest request = HelloRequest.newBuilder().setName("Armerian").build();
 
         try {
-            Hello.HelloReply reply = blockingStub.unavailable(request);
+            HelloReply reply = blockingStub.unimplemented(request);
 
             // Should never reach these assertions.
             assertEquals("Hello, Armerian World!!", reply.getMessage());

--- a/src/test/java/cloud/filibuster/functional/java_hello/JUnitFilibusterHelloUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/java_hello/JUnitFilibusterHelloUnimplementedTest.java
@@ -99,7 +99,7 @@ public class JUnitFilibusterHelloUnimplementedTest extends JUnitBaseTest {
                     throw t;
                 }
             } else {
-                if (t.getMessage().equals("DATA_LOSS: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method cloud.filibuster.examples.WorldService/WorldUnavailable is unimplemented")) {
+                if (t.getMessage().equals("DATA_LOSS: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method cloud.filibuster.examples.WorldService/WorldUnimplemented is unimplemented")) {
                     expected = true;
                 }
 

--- a/src/test/java/cloud/filibuster/functional/java_hello/JUnitFilibusterHelloUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/java_hello/JUnitFilibusterHelloUnimplementedTest.java
@@ -1,12 +1,11 @@
-package cloud.filibuster.functional.java.bfs;
+package cloud.filibuster.functional.java_hello;
 
 import cloud.filibuster.examples.Hello;
 import cloud.filibuster.examples.HelloServiceGrpc;
-import cloud.filibuster.functional.JUnitBaseTest;
 import cloud.filibuster.instrumentation.helpers.Networking;
-import cloud.filibuster.junit.FilibusterSearchStrategy;
 import cloud.filibuster.junit.FilibusterTest;
 import cloud.filibuster.junit.server.backends.FilibusterLocalServerBackend;
+import cloud.filibuster.functional.JUnitBaseTest;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import org.junit.jupiter.api.DisplayName;
@@ -32,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Test simple annotation usage.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class JUnitFilibusterHelloUnavailableTest extends JUnitBaseTest {
+public class JUnitFilibusterHelloUnimplementedTest extends JUnitBaseTest {
     private final static Set<String> testExceptionsThrown = new HashSet<>();
 
     private static int numberOfTestsExecuted = 0;
@@ -40,7 +39,7 @@ public class JUnitFilibusterHelloUnavailableTest extends JUnitBaseTest {
     private static int numberOfExceptionsThrown = 0;
 
     @DisplayName("Test partial hello server grpc route with Filibuster. (MyHelloService, MyWorldService)")
-    @FilibusterTest(serverBackend=FilibusterLocalServerBackend.class, searchStrategy= FilibusterSearchStrategy.BFS, maxIterations=10)
+    @FilibusterTest(serverBackend=FilibusterLocalServerBackend.class, maxIterations=10)
     @Order(1)
     public void testMyHelloAndMyWorldServiceWithFilibuster() throws InterruptedException {
         ManagedChannel helloChannel = ManagedChannelBuilder
@@ -56,7 +55,7 @@ public class JUnitFilibusterHelloUnavailableTest extends JUnitBaseTest {
         Hello.HelloRequest request = Hello.HelloRequest.newBuilder().setName("Armerian").build();
 
         try {
-            Hello.HelloReply reply = blockingStub.unavailable(request);
+            Hello.HelloReply reply = blockingStub.unimplemented(request);
 
             // Should never reach these assertions.
             assertEquals("Hello, Armerian World!!", reply.getMessage());

--- a/src/test/java/cloud/filibuster/functional/python/basic/JUnitFilibusterUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/python/basic/JUnitFilibusterUnimplementedTest.java
@@ -54,7 +54,7 @@ public class JUnitFilibusterUnimplementedTest extends JUnitBaseTest {
                 assertThat(e.getMessage(), containsString("DATA_LOSS: io.grpc.StatusRuntimeException:"));
             } else {
                 // Actual response when the remote service is online but unimplemented.
-                assertEquals("DATA_LOSS: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method cloud.filibuster.examples.WorldService/WorldUnavailable is unimplemented", e.getMessage());
+                assertEquals("DATA_LOSS: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method cloud.filibuster.examples.WorldService/WorldUnimplemented is unimplemented", e.getMessage());
             }
         }
 

--- a/src/test/java/cloud/filibuster/functional/python/basic/JUnitFilibusterUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/python/basic/JUnitFilibusterUnimplementedTest.java
@@ -1,10 +1,13 @@
-package cloud.filibuster.functional.java.basic;
+package cloud.filibuster.functional.python.basic;
 
 import cloud.filibuster.examples.Hello;
+import cloud.filibuster.examples.Hello.HelloRequest;
 import cloud.filibuster.examples.HelloServiceGrpc;
+import cloud.filibuster.examples.HelloServiceGrpc.HelloServiceBlockingStub;
 import cloud.filibuster.instrumentation.helpers.Networking;
 import cloud.filibuster.junit.FilibusterTest;
-import cloud.filibuster.junit.server.backends.FilibusterLocalServerBackend;
+import cloud.filibuster.junit.interceptors.GitHubActionsSkipInvocationInterceptor;
+import cloud.filibuster.junit.server.backends.FilibusterLocalProcessServerBackend;
 import cloud.filibuster.functional.JUnitBaseTest;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -14,6 +17,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -26,11 +30,12 @@ import static org.testcontainers.shaded.org.hamcrest.MatcherAssert.assertThat;
 import static org.testcontainers.shaded.org.hamcrest.Matchers.containsString;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class JUnitFilibusterUnavailableTest extends JUnitBaseTest {
+public class JUnitFilibusterUnimplementedTest extends JUnitBaseTest {
     private final static Set<String> testExceptionsThrown = new HashSet<>();
 
     @DisplayName("Test partial hello server grpc route with Filibuster. (MyHelloService, MyWorldService)")
-    @FilibusterTest(serverBackend=FilibusterLocalServerBackend.class)
+    @ExtendWith(GitHubActionsSkipInvocationInterceptor.class)
+    @FilibusterTest(serverBackend=FilibusterLocalProcessServerBackend.class)
     @Order(1)
     public void testMyHelloAndMyWorldServiceWithFilibuster() throws InterruptedException {
         ManagedChannel helloChannel = ManagedChannelBuilder
@@ -39,9 +44,9 @@ public class JUnitFilibusterUnavailableTest extends JUnitBaseTest {
                 .build();
 
         try {
-            HelloServiceGrpc.HelloServiceBlockingStub blockingStub = HelloServiceGrpc.newBlockingStub(helloChannel);
-            Hello.HelloRequest request = Hello.HelloRequest.newBuilder().setName("Armerian").build();
-            blockingStub.unavailable(request);
+            HelloServiceBlockingStub blockingStub = HelloServiceGrpc.newBlockingStub(helloChannel);
+            HelloRequest request = HelloRequest.newBuilder().setName("Armerian").build();
+            blockingStub.unimplemented(request);
             assertTrue(false);
         } catch (StatusRuntimeException e) {
             if (wasFaultInjected()) {
@@ -61,6 +66,7 @@ public class JUnitFilibusterUnavailableTest extends JUnitBaseTest {
      * Verify that Filibuster generated the correct number of fault injections.
      */
     @DisplayName("Verify correct number of generated Filibuster tests.")
+    @ExtendWith(GitHubActionsSkipInvocationInterceptor.class)
     @Test
     @Order(2)
     public void testNumAssertions() {

--- a/src/test/java/cloud/filibuster/functional/python/basic/JUnitFilibusterUnimplementedTest.java
+++ b/src/test/java/cloud/filibuster/functional/python/basic/JUnitFilibusterUnimplementedTest.java
@@ -1,6 +1,5 @@
 package cloud.filibuster.functional.python.basic;
 
-import cloud.filibuster.examples.Hello;
 import cloud.filibuster.examples.Hello.HelloRequest;
 import cloud.filibuster.examples.HelloServiceGrpc;
 import cloud.filibuster.examples.HelloServiceGrpc.HelloServiceBlockingStub;

--- a/src/test/java/cloud/filibuster/integration/examples/armeria/grpc/test_services/MyHelloService.java
+++ b/src/test/java/cloud/filibuster/integration/examples/armeria/grpc/test_services/MyHelloService.java
@@ -331,7 +331,7 @@ public class MyHelloService extends HelloServiceGrpc.HelloServiceImplBase {
     }
 
     @Override
-    public void unavailable(Hello.HelloRequest req, StreamObserver<Hello.HelloReply> responseObserver) {
+    public void unimplemented(Hello.HelloRequest req, StreamObserver<Hello.HelloReply> responseObserver) {
         // build stub with decorator or interceptor
         if (!shouldUseDecorator) {
             ManagedChannel originalChannel = ManagedChannelBuilder
@@ -352,7 +352,7 @@ public class MyHelloService extends HelloServiceGrpc.HelloServiceImplBase {
             try {
                 WorldServiceGrpc.WorldServiceBlockingStub blockingStub = WorldServiceGrpc.newBlockingStub(channel);
                 Hello.WorldRequest request = Hello.WorldRequest.newBuilder().setName(req.getName()).build();
-                Hello.WorldReply worldReply = blockingStub.worldUnavailable(request);
+                Hello.WorldReply worldReply = blockingStub.worldUnimplemented(request);
 
                 Hello.HelloReply reply = Hello.HelloReply.newBuilder()
                         .setMessage("Hello, " + worldReply.getMessage())
@@ -392,7 +392,7 @@ public class MyHelloService extends HelloServiceGrpc.HelloServiceImplBase {
                 WorldServiceGrpc.WorldServiceBlockingStub blockingStub =
                         grpcClientBuilder.build(WorldServiceGrpc.WorldServiceBlockingStub.class);
                 Hello.WorldRequest request = Hello.WorldRequest.newBuilder().setName(req.getName()).build();
-                Hello.WorldReply worldReply = blockingStub.worldUnavailable(request);
+                Hello.WorldReply worldReply = blockingStub.worldUnimplemented(request);
 
                 Hello.HelloReply reply = Hello.HelloReply.newBuilder()
                         .setMessage("Hello, " + worldReply.getMessage())

--- a/src/test/java/cloud/filibuster/integration/examples/armeria/grpc/tests/decorators/scenarios/HelloGrpcServerTestWithHelloAndFilibusterServerFakeNoFaultTest.java
+++ b/src/test/java/cloud/filibuster/integration/examples/armeria/grpc/tests/decorators/scenarios/HelloGrpcServerTestWithHelloAndFilibusterServerFakeNoFaultTest.java
@@ -99,7 +99,7 @@ public class HelloGrpcServerTestWithHelloAndFilibusterServerFakeNoFaultTest exte
         VectorClock assertVc = generateAssertionClock();
         assertEquals(assertVc.toString(), lastPayload.get("vclock").toString());
 
-        assertEquals("[[\"V1-a94a8fe5ccb19ba61c4c0873d391e987982fbbd3-02be70093aa1244da10bd3b32514e8b3233ac30e-d1cea17124375b2b5755215aa248d091c197acf5-146409d9c7d501362ce2f58ab555782fba01c7c6\", 1]]", lastPayload.getString("execution_index"));
+        assertEquals("[[\"V1-a94a8fe5ccb19ba61c4c0873d391e987982fbbd3-02be70093aa1244da10bd3b32514e8b3233ac30e-a4db5eb7244470407d1785effbc6c33e359615d4-146409d9c7d501362ce2f58ab555782fba01c7c6\", 1]]", lastPayload.getString("execution_index"));
 
         assertFalse(wasFaultInjected());
     }

--- a/src/test/java/cloud/filibuster/unit/TestExecutionTest.java
+++ b/src/test/java/cloud/filibuster/unit/TestExecutionTest.java
@@ -32,8 +32,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe1 = new AbstractTestExecution();
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
         assertEquals(pe1, pe2);
     }
 
@@ -55,8 +55,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex1, jsonObject);
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex2, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex1, jsonObject);
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex2, jsonObject);
         assertEquals(pe1, pe2);
     }
 
@@ -71,14 +71,14 @@ public class TestExecutionTest {
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, new JSONObject());
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, new JSONObject());
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, new JSONObject());
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, new JSONObject());
         assertEquals(pe1, pe2);
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("a", "b");
 
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
         assertNotEquals(pe1, pe2);
     }
 
@@ -98,8 +98,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex1, new JSONObject());
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex2, new JSONObject());
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex1, new JSONObject());
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex2, new JSONObject());
         assertEquals(pe1, pe2);
     }
 
@@ -118,8 +118,8 @@ public class TestExecutionTest {
         JSONObject jsonObject = new JSONObject();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
         assertEquals(pe1, pe2);
     }
 
@@ -136,8 +136,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, new JSONObject());
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, new JSONObject());
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, new JSONObject());
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, new JSONObject());
         assertEquals(pe1, pe2);
     }
 
@@ -160,8 +160,8 @@ public class TestExecutionTest {
         JSONObject jsonObject = new JSONObject();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex1, jsonObject);
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex2, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex1, jsonObject);
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex2, jsonObject);
         assertEquals(pe1, pe2);
     }
 
@@ -182,8 +182,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex1, new JSONObject());
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex2, new JSONObject());
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex1, new JSONObject());
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex2, new JSONObject());
         assertEquals(pe1, pe2);
     }
 
@@ -201,8 +201,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe1 = new AbstractTestExecution();
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
 
         pe1.addFaultToInject(distributedExecutionIndex, jsonObject);
         pe2.addFaultToInject(distributedExecutionIndex, jsonObject);
@@ -228,8 +228,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex1, jsonObject);
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex2, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex1, jsonObject);
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex2, jsonObject);
 
         pe1.addFaultToInject(distributedExecutionIndex1, jsonObject);
         pe2.addFaultToInject(distributedExecutionIndex2, jsonObject);
@@ -248,8 +248,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, new JSONObject());
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, new JSONObject());
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, new JSONObject());
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, new JSONObject());
 
         pe1.addFaultToInject(distributedExecutionIndex, new JSONObject());
         pe2.addFaultToInject(distributedExecutionIndex, new JSONObject());
@@ -259,7 +259,7 @@ public class TestExecutionTest {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("a", "b");
 
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
         assertNotEquals(pe1, pe2);
     }
 
@@ -279,8 +279,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex1, new JSONObject());
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex2, new JSONObject());
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex1, new JSONObject());
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex2, new JSONObject());
 
         pe1.addFaultToInject(distributedExecutionIndex1, new JSONObject());
         pe2.addFaultToInject(distributedExecutionIndex2, new JSONObject());
@@ -303,8 +303,8 @@ public class TestExecutionTest {
         JSONObject jsonObject = new JSONObject();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
 
         pe1.addFaultToInject(distributedExecutionIndex, jsonObject);
         pe2.addFaultToInject(distributedExecutionIndex, jsonObject);
@@ -325,8 +325,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, new JSONObject());
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, new JSONObject());
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, new JSONObject());
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, new JSONObject());
 
         pe1.addFaultToInject(distributedExecutionIndex, new JSONObject());
         pe2.addFaultToInject(distributedExecutionIndex, new JSONObject());
@@ -353,8 +353,8 @@ public class TestExecutionTest {
         JSONObject jsonObject = new JSONObject();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex1, jsonObject);
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex2, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex1, jsonObject);
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex2, jsonObject);
 
         pe1.addFaultToInject(distributedExecutionIndex1, jsonObject);
         pe2.addFaultToInject(distributedExecutionIndex2, jsonObject);
@@ -379,8 +379,8 @@ public class TestExecutionTest {
         AbstractTestExecution pe2 = new AbstractTestExecution();
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex1, new JSONObject());
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex2, new JSONObject());
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex1, new JSONObject());
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex2, new JSONObject());
 
         pe1.addFaultToInject(distributedExecutionIndex1, new JSONObject());
         pe2.addFaultToInject(distributedExecutionIndex2, new JSONObject());
@@ -406,14 +406,14 @@ public class TestExecutionTest {
         jsonObject2.put("thing", "thing");
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject1);
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject2);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject1);
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject2);
         assertEquals(pe1, pe2);
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("a", "b");
 
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex, jsonObject);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, jsonObject);
         assertNotEquals(pe1, pe2);
     }
 
@@ -438,8 +438,8 @@ public class TestExecutionTest {
         jsonObject2.put("thing", "thing");
 
         // If this fails, we know the difference has to be in the JSONObject comparison, since the keys are the same.
-        pe1.addDistributedExecutionIndexWithPayload(distributedExecutionIndex1, jsonObject1);
-        pe2.addDistributedExecutionIndexWithPayload(distributedExecutionIndex2, jsonObject2);
+        pe1.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex1, jsonObject1);
+        pe2.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex2, jsonObject2);
         assertEquals(pe1, pe2);
     }
 }


### PR DESCRIPTION
### Cleanup of Test Report

- [x] Unavailable test should actually be called unimplemented (also, the GRPC endpoints too.)
- [x] Body of invocation_complete response should contained the serialized response message.
- [x] Ensure unimplemented responses show clearly in the output and put some sort of description about what this means.
- [x] Add actual response in the test report.
- [x] Include invocation number.
- [x] Include pass/fail status.
- [x] Render cause in the test report.

### Other

- [x] Fix printRPCs to be like the other loggers.
- [x] Creation of Aggregate Test Report that displays all of the generated tests and their status.
- [x] Extension to display Aggregate Test Report

