### PR TITLE
Callsite reversal is a bug.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.6.3:
+   - (cmeiklejohn) Fix bug with call site generation using incorrect frame for call site.
 1.6.2:
    - (cmeiklejohn) Add support for M1 macs.
 1.6.1:

--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ javadoc {
 
 group = "cloud.filibuster"
 archivesBaseName = "instrumentation"
-version = "1.6.2"
+version = "1.6.3"
 
 java {
     withJavadocJar()

--- a/src/main/java/cloud/filibuster/instrumentation/datatypes/Callsite.java
+++ b/src/main/java/cloud/filibuster/instrumentation/datatypes/Callsite.java
@@ -87,9 +87,6 @@ public class Callsite {
         }
         this.serializedStackTrace = String.join("", arraySerializedArguments);
 
-        // Ensure we reverse frames so 0 is the first frame.
-        Collections.reverse(filteredStackTrace);
-
         // Get last element and compute callsite file name and line number.
         Map.Entry<String, String> lastStackTraceElement = filteredStackTrace.get(0);
         String lastStackTraceElementString = lastStackTraceElement.getValue();

--- a/src/main/java/cloud/filibuster/instrumentation/datatypes/Callsite.java
+++ b/src/main/java/cloud/filibuster/instrumentation/datatypes/Callsite.java
@@ -103,7 +103,6 @@ public class Callsite {
             throw e;
         }
 
-
         if (getCallsiteLineNumberProperty()) {
             this.lineNumber = lastStackTraceElementString.substring(lastStackTraceElementString.indexOf(':') + 1, lastStackTraceElementString.indexOf(')'));
         } else {

--- a/src/test/java/cloud/filibuster/integration/examples/armeria/grpc/tests/decorators/scenarios/HelloGrpcServerTestWithHelloAndFilibusterServerFakeWithCauseTest.java
+++ b/src/test/java/cloud/filibuster/integration/examples/armeria/grpc/tests/decorators/scenarios/HelloGrpcServerTestWithHelloAndFilibusterServerFakeWithCauseTest.java
@@ -105,6 +105,6 @@ public class HelloGrpcServerTestWithHelloAndFilibusterServerFakeWithCauseTest ex
         VectorClock assertVc = generateAssertionClock();
         assertEquals(assertVc.toString(), lastPayload.get("vclock").toString());
 
-        assertEquals("[[\"V1-da39a3ee5e6b4b0d3255bfef95601890afd80709-a94a8fe5ccb19ba61c4c0873d391e987982fbbd3-02be70093aa1244da10bd3b32514e8b3233ac30e-d318a5012701e86522e95de4a9654bf4ed9952b1-e3b858152435d0cadc132349ad51d97a785b20b4\", 1]]", lastPayload.getString("execution_index"));
+        assertEquals("[[\"V1-da39a3ee5e6b4b0d3255bfef95601890afd80709-a94a8fe5ccb19ba61c4c0873d391e987982fbbd3-02be70093aa1244da10bd3b32514e8b3233ac30e-221f40f106a31021aaf9405e969478f21d2696db-e3b858152435d0cadc132349ad51d97a785b20b4\", 1]]", lastPayload.getString("execution_index"));
     }
 }

--- a/src/test/java/cloud/filibuster/integration/examples/armeria/grpc/tests/decorators/scenarios/HelloGrpcServerTestWithHelloAndFilibusterServerFakeWithDescriptionTest.java
+++ b/src/test/java/cloud/filibuster/integration/examples/armeria/grpc/tests/decorators/scenarios/HelloGrpcServerTestWithHelloAndFilibusterServerFakeWithDescriptionTest.java
@@ -101,6 +101,6 @@ public class HelloGrpcServerTestWithHelloAndFilibusterServerFakeWithDescriptionT
         VectorClock assertVc = generateAssertionClock();
         assertEquals(assertVc.toString(), lastPayload.get("vclock").toString());
 
-        assertEquals("[[\"V1-da39a3ee5e6b4b0d3255bfef95601890afd80709-a94a8fe5ccb19ba61c4c0873d391e987982fbbd3-02be70093aa1244da10bd3b32514e8b3233ac30e-f8bde40fd4ee4de09c9727c7a8727dd53113de56-e3b858152435d0cadc132349ad51d97a785b20b4\", 1]]", lastPayload.getString("execution_index"));
+        assertEquals("[[\"V1-da39a3ee5e6b4b0d3255bfef95601890afd80709-a94a8fe5ccb19ba61c4c0873d391e987982fbbd3-02be70093aa1244da10bd3b32514e8b3233ac30e-1aa66c5ca169c200037d10fbf936196e58acbdba-e3b858152435d0cadc132349ad51d97a785b20b4\", 1]]", lastPayload.getString("execution_index"));
     }
 }

--- a/src/test/java/cloud/filibuster/integration/examples/armeria/grpc/tests/interceptors/HelloGrpcServerTestWithHelloAndFilibusterServerFakeTest.java
+++ b/src/test/java/cloud/filibuster/integration/examples/armeria/grpc/tests/interceptors/HelloGrpcServerTestWithHelloAndFilibusterServerFakeTest.java
@@ -154,7 +154,7 @@ public class HelloGrpcServerTestWithHelloAndFilibusterServerFakeTest extends Hel
         assertVc.incrementClock("test");
         assertEquals(assertVc.toString(), lastPayload.get("vclock").toString());
 
-        assertEquals("[[\"V1-da39a3ee5e6b4b0d3255bfef95601890afd80709-a94a8fe5ccb19ba61c4c0873d391e987982fbbd3-02be70093aa1244da10bd3b32514e8b3233ac30e-3a5406844cfedf6cca8d5acf7de50ff09632e909-51d0c6d179f06a73c7c08e98dc587a0f89598884\", 1]]", lastPayload.getString("execution_index"));
+        assertEquals("[[\"V1-da39a3ee5e6b4b0d3255bfef95601890afd80709-a94a8fe5ccb19ba61c4c0873d391e987982fbbd3-02be70093aa1244da10bd3b32514e8b3233ac30e-7e8c44021a00d4cd9d5e8a10b411af4752ed2d08-51d0c6d179f06a73c7c08e98dc587a0f89598884\", 1]]", lastPayload.getString("execution_index"));
 
         MyHelloService.shouldReturnRuntimeExceptionWithDescription = false;
         FilibusterClientInterceptor.disableInstrumentation = true;
@@ -188,7 +188,7 @@ public class HelloGrpcServerTestWithHelloAndFilibusterServerFakeTest extends Hel
         assertVc.incrementClock("test");
         assertEquals(assertVc.toString(), lastPayload.get("vclock").toString());
 
-        assertEquals("[[\"V1-da39a3ee5e6b4b0d3255bfef95601890afd80709-a94a8fe5ccb19ba61c4c0873d391e987982fbbd3-02be70093aa1244da10bd3b32514e8b3233ac30e-3851265cecf327363ff11a32c5677ca3ee3d7b95-51d0c6d179f06a73c7c08e98dc587a0f89598884\", 1]]", lastPayload.getString("execution_index"));
+        assertEquals("[[\"V1-da39a3ee5e6b4b0d3255bfef95601890afd80709-a94a8fe5ccb19ba61c4c0873d391e987982fbbd3-02be70093aa1244da10bd3b32514e8b3233ac30e-ee094f0de4e3e456c494cff85458fa7a04a6478d-51d0c6d179f06a73c7c08e98dc587a0f89598884\", 1]]", lastPayload.getString("execution_index"));
 
         MyHelloService.shouldReturnRuntimeExceptionWithCause = false;
         FilibusterClientInterceptor.disableInstrumentation = true;


### PR DESCRIPTION
This only targets the first frame, therefore the entry into the application.  If a function is used to make the RPC, this captures the entry to the function; not the location in the function where the RPC was made.

Should have little effect: this is only used for debugging.

- [x] CHANGELOG
- [x] build.gradle