### PR TITLE
Add RPC caching option.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 1.6.3:
    - (cmeiklejohn) Fix bug with call site generation using incorrect frame for call site.
+   - (cmeiklejohn) Add assume RPC caching option.
 1.6.2:
    - (cmeiklejohn) Add support for M1 macs.
 1.6.1:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.6.3:
+   - (cmeiklejohn) Fix bug with call site generation using incorrect frame for call site.
 1.6.2:
    - (cmeiklejohn) Add support for M1 macs.
 1.6.1:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.6.3:
    - (cmeiklejohn) Fix bug with call site generation using incorrect frame for call site.
-   - (cmeiklejohn) Add assume RPC caching option.
+   - (cmeiklejohn) Add avoid redundant RPC option for caching use cases.
+   - (cmeiklejohn) Add option to hide cached entries from the UX.
 1.6.2:
    - (cmeiklejohn) Add support for M1 macs.
 1.6.1:

--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ javadoc {
 
 group = "cloud.filibuster"
 archivesBaseName = "instrumentation"
-version = "1.6.2"
+version = "1.6.3"
 
 java {
     withJavadocJar()

--- a/src/main/java/cloud/filibuster/instrumentation/datatypes/Callsite.java
+++ b/src/main/java/cloud/filibuster/instrumentation/datatypes/Callsite.java
@@ -11,7 +11,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/src/main/java/cloud/filibuster/instrumentation/helpers/Networking.java
+++ b/src/main/java/cloud/filibuster/instrumentation/helpers/Networking.java
@@ -45,6 +45,8 @@ public class Networking {
                     return 5006;
                 case "hello-mock":
                     return 6002;
+                case "user-mock":
+                    return 6007;
                 default:
                     RuntimeException re = new MissingServiceSpecificationException();
                     re.initCause(e);

--- a/src/main/java/cloud/filibuster/instrumentation/helpers/Property.java
+++ b/src/main/java/cloud/filibuster/instrumentation/helpers/Property.java
@@ -146,6 +146,28 @@ public class Property {
     }
 
     /***********************************************************************************
+     ** filibuster.test.assume_rpc_caching
+     ***********************************************************************************/
+
+    public static final boolean ASSUME_RPC_CACHING_DEFAULT = false;
+
+    private final static String TEST_ASSUME_RPC_CACHING = "filibuster.test.assume_rpc_caching";
+
+    public static void setTestAssumeRpcCachingProperty(boolean value) {
+        System.setProperty(TEST_ASSUME_RPC_CACHING, String.valueOf(value));
+    }
+
+    public static boolean getTestAssumeRpcCachingProperty() {
+        String propertyValue = System.getProperty(TEST_ASSUME_RPC_CACHING);
+
+        if (isPropertyNull(propertyValue)) {
+            return ASSUME_RPC_CACHING_DEFAULT;
+        } else {
+            return Boolean.valueOf(propertyValue);
+        }
+    }
+
+    /***********************************************************************************
      ** filibuster.test.data_nondeterminism
      ***********************************************************************************/
 

--- a/src/main/java/cloud/filibuster/instrumentation/helpers/Property.java
+++ b/src/main/java/cloud/filibuster/instrumentation/helpers/Property.java
@@ -146,22 +146,22 @@ public class Property {
     }
 
     /***********************************************************************************
-     ** filibuster.test.assume_rpc_caching
+     ** filibuster.test.avoid_redundant_injections
      ***********************************************************************************/
 
-    public static final boolean ASSUME_RPC_CACHING_DEFAULT = false;
+    public static final boolean AVOID_REDUNDANT_INJECTIONS_DEFAULT = false;
 
-    private final static String TEST_ASSUME_RPC_CACHING = "filibuster.test.assume_rpc_caching";
+    private final static String TEST_AVOID_REDUNDANT_INJECTIONS = "filibuster.test.avoid_redundant_injections";
 
-    public static void setTestAssumeRpcCachingProperty(boolean value) {
-        System.setProperty(TEST_ASSUME_RPC_CACHING, String.valueOf(value));
+    public static void setTestAvoidRedundantInjectionsProperty(boolean value) {
+        System.setProperty(TEST_AVOID_REDUNDANT_INJECTIONS, String.valueOf(value));
     }
 
-    public static boolean getTestAssumeRpcCachingProperty() {
-        String propertyValue = System.getProperty(TEST_ASSUME_RPC_CACHING);
+    public static boolean getTestAvoidRedundantInjectionsProperty() {
+        String propertyValue = System.getProperty(TEST_AVOID_REDUNDANT_INJECTIONS);
 
         if (isPropertyNull(propertyValue)) {
-            return ASSUME_RPC_CACHING_DEFAULT;
+            return AVOID_REDUNDANT_INJECTIONS_DEFAULT;
         } else {
             return Boolean.valueOf(propertyValue);
         }

--- a/src/main/java/cloud/filibuster/junit/TestWithFilibuster.java
+++ b/src/main/java/cloud/filibuster/junit/TestWithFilibuster.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Isolated;
 
-import static cloud.filibuster.instrumentation.helpers.Property.ASSUME_RPC_CACHING_DEFAULT;
+import static cloud.filibuster.instrumentation.helpers.Property.AVOID_REDUNDANT_INJECTIONS_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.DATA_NONDETERMINISM_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.MAX_ITERATIONS_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.SUPPRESS_COMBINATIONS_DEFAULT;
@@ -153,13 +153,13 @@ public @interface TestWithFilibuster {
     boolean dataNondeterminism() default DATA_NONDETERMINISM_DEFAULT;
 
     /**
-     * Should we assume that RPCs are cached?
+     * Should we avoid redundant fault injections?
      *
      * <p>If so, repeated execution of the same RPC method with the same RPC arguments will be skipped for fault injection.
      *
-     * @return whether caching is assumed.
+     * @return whether we should avoid redundant injections
      */
-    boolean assumeRpcCaching() default ASSUME_RPC_CACHING_DEFAULT;
+    boolean avoidRedundantInjections() default AVOID_REDUNDANT_INJECTIONS_DEFAULT;
 
     /**
      * Analysis file that should be used for this configuration of Filibuster.

--- a/src/main/java/cloud/filibuster/junit/TestWithFilibuster.java
+++ b/src/main/java/cloud/filibuster/junit/TestWithFilibuster.java
@@ -157,6 +157,8 @@ public @interface TestWithFilibuster {
      *
      * <p>If so, repeated execution of the same RPC method with the same RPC arguments will be skipped for fault injection.
      *
+     * <p>Option will still show RPCs as redundant in the UX, to avoid set the system property instead.
+     *
      * @return whether we should avoid redundant injections
      */
     boolean avoidRedundantInjections() default AVOID_REDUNDANT_INJECTIONS_DEFAULT;

--- a/src/main/java/cloud/filibuster/junit/TestWithFilibuster.java
+++ b/src/main/java/cloud/filibuster/junit/TestWithFilibuster.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Isolated;
 
+import static cloud.filibuster.instrumentation.helpers.Property.ASSUME_RPC_CACHING_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.DATA_NONDETERMINISM_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.MAX_ITERATIONS_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.SUPPRESS_COMBINATIONS_DEFAULT;
@@ -150,6 +151,15 @@ public @interface TestWithFilibuster {
      * @return whether data nondeterminism is present in the test.
      */
     boolean dataNondeterminism() default DATA_NONDETERMINISM_DEFAULT;
+
+    /**
+     * Should we assume that RPCs are cached?
+     *
+     * <p>If so, repeated execution of the same RPC method with the same RPC arguments will be skipped for fault injection.
+     *
+     * @return whether caching is assumed.
+     */
+    boolean assumeRpcCaching() default ASSUME_RPC_CACHING_DEFAULT;
 
     /**
      * Analysis file that should be used for this configuration of Filibuster.

--- a/src/main/java/cloud/filibuster/junit/configuration/FilibusterConfiguration.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/FilibusterConfiguration.java
@@ -31,7 +31,7 @@ public class FilibusterConfiguration {
 
     private final boolean dataNondeterminism;
 
-    private final boolean assumeRpcCaching;
+    private final boolean avoidRedundantInjections;
 
     private final FilibusterSearchStrategy searchStrategy;
 
@@ -59,7 +59,7 @@ public class FilibusterConfiguration {
         this.dynamicReduction = builder.dynamicReduction;
         this.suppressCombinations = builder.suppressCombinations;
         this.dataNondeterminism = builder.dataNondeterminism;
-        this.assumeRpcCaching = builder.assumeRpcCaching;
+        this.avoidRedundantInjections = builder.avoidRedundantInjections;
         this.searchStrategy = builder.searchStrategy;
         this.analysisFile = builder.analysisFile;
         this.serverBackend = builder.serverBackend;
@@ -110,12 +110,12 @@ public class FilibusterConfiguration {
     }
 
     /**
-     * Do we assume RPC caching?
+     * Do we avoid redundant injections?
      *
      * @return boolean
      */
-    public boolean getAssumeRpcCaching() {
-        return this.assumeRpcCaching;
+    public boolean getAvoidRedundantInjections() {
+        return this.avoidRedundantInjections;
     }
 
     /**
@@ -237,7 +237,7 @@ public class FilibusterConfiguration {
         private boolean dynamicReduction = false;
         private boolean suppressCombinations = false;
         private boolean dataNondeterminism = false;
-        private boolean assumeRpcCaching = false;
+        private boolean avoidRedundantInjections = false;
 
         private FilibusterSearchStrategy searchStrategy;
 
@@ -297,14 +297,14 @@ public class FilibusterConfiguration {
         }
 
         /**
-         * Does this test configuration assume RPC caching?
+         * Do we avoid redundant fault injections?
          *
-         * @param assumeRpcCaching whether the test configuration assumes RPC caching
+         * @param avoidRedundantInjections whether the avoids redundant fault injections
          * @return builder
          */
         @CanIgnoreReturnValue
-        public Builder assumeRpcCaching(boolean assumeRpcCaching) {
-            this.assumeRpcCaching = assumeRpcCaching;
+        public Builder avoidRedundantInjections(boolean avoidRedundantInjections) {
+            this.avoidRedundantInjections = avoidRedundantInjections;
             return this;
         }
 

--- a/src/main/java/cloud/filibuster/junit/configuration/FilibusterConfiguration.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/FilibusterConfiguration.java
@@ -31,6 +31,8 @@ public class FilibusterConfiguration {
 
     private final boolean dataNondeterminism;
 
+    private final boolean assumeRpcCaching;
+
     private final FilibusterSearchStrategy searchStrategy;
 
     private final String analysisFile;
@@ -57,6 +59,7 @@ public class FilibusterConfiguration {
         this.dynamicReduction = builder.dynamicReduction;
         this.suppressCombinations = builder.suppressCombinations;
         this.dataNondeterminism = builder.dataNondeterminism;
+        this.assumeRpcCaching = builder.assumeRpcCaching;
         this.searchStrategy = builder.searchStrategy;
         this.analysisFile = builder.analysisFile;
         this.serverBackend = builder.serverBackend;
@@ -104,6 +107,15 @@ public class FilibusterConfiguration {
      */
     public boolean getDataNondeterminism() {
         return this.dataNondeterminism;
+    }
+
+    /**
+     * Do we assume RPC caching?
+     *
+     * @return boolean
+     */
+    public boolean getAssumeRpcCaching() {
+        return this.assumeRpcCaching;
     }
 
     /**
@@ -225,6 +237,7 @@ public class FilibusterConfiguration {
         private boolean dynamicReduction = false;
         private boolean suppressCombinations = false;
         private boolean dataNondeterminism = false;
+        private boolean assumeRpcCaching = false;
 
         private FilibusterSearchStrategy searchStrategy;
 
@@ -280,6 +293,18 @@ public class FilibusterConfiguration {
         @CanIgnoreReturnValue
         public Builder dataNondeterminism(boolean dataNondeterminism) {
             this.dataNondeterminism = dataNondeterminism;
+            return this;
+        }
+
+        /**
+         * Does this test configuration assume RPC caching?
+         *
+         * @param assumeRpcCaching whether the test configuration assumes RPC caching
+         * @return builder
+         */
+        @CanIgnoreReturnValue
+        public Builder assumeRpcCaching(boolean assumeRpcCaching) {
+            this.assumeRpcCaching = assumeRpcCaching;
             return this;
         }
 

--- a/src/main/java/cloud/filibuster/junit/extensions/FilibusterTestExtension.java
+++ b/src/main/java/cloud/filibuster/junit/extensions/FilibusterTestExtension.java
@@ -26,14 +26,14 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.Preconditions;
 
-import static cloud.filibuster.instrumentation.helpers.Property.ASSUME_RPC_CACHING_DEFAULT;
+import static cloud.filibuster.instrumentation.helpers.Property.AVOID_REDUNDANT_INJECTIONS_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.DATA_NONDETERMINISM_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.MAX_ITERATIONS_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.SUPPRESS_COMBINATIONS_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.getEnabledProperty;
 import static cloud.filibuster.instrumentation.helpers.Property.getServerBackendDockerImageNameProperty;
 import static cloud.filibuster.instrumentation.helpers.Property.getTestAnalysisResourceFileProperty;
-import static cloud.filibuster.instrumentation.helpers.Property.getTestAssumeRpcCachingProperty;
+import static cloud.filibuster.instrumentation.helpers.Property.getTestAvoidRedundantInjectionsProperty;
 import static cloud.filibuster.instrumentation.helpers.Property.getTestDataNondeterminismProperty;
 import static cloud.filibuster.instrumentation.helpers.Property.getTestMaxIterationsProperty;
 import static cloud.filibuster.instrumentation.helpers.Property.getTestSuppressCombinationsProperty;
@@ -100,11 +100,11 @@ public class FilibusterTestExtension implements TestTemplateInvocationContextPro
             dataNondeterminism = getTestDataNondeterminismProperty();
         }
 
-        boolean assumeRpcCaching = testWithFilibuster.assumeRpcCaching();
+        boolean avoidRedundantInjections = testWithFilibuster.avoidRedundantInjections();
 
-        if (assumeRpcCaching == ASSUME_RPC_CACHING_DEFAULT) {
+        if (avoidRedundantInjections == AVOID_REDUNDANT_INJECTIONS_DEFAULT) {
             // Check the property to see if it was set.
-            assumeRpcCaching = getTestAssumeRpcCachingProperty();
+            avoidRedundantInjections = getTestAvoidRedundantInjectionsProperty();
         }
 
         boolean suppressCombinations = testWithFilibuster.suppressCombinations();
@@ -118,7 +118,7 @@ public class FilibusterTestExtension implements TestTemplateInvocationContextPro
                 .dynamicReduction(testWithFilibuster.dynamicReduction())
                 .suppressCombinations(suppressCombinations)
                 .dataNondeterminism(dataNondeterminism)
-                .assumeRpcCaching(assumeRpcCaching)
+                .avoidRedundantInjections(avoidRedundantInjections)
                 .serverBackend(testWithFilibuster.serverBackend())
                 .searchStrategy(testWithFilibuster.searchStrategy())
                 .dockerImageName(dockerImageName)

--- a/src/main/java/cloud/filibuster/junit/extensions/FilibusterTestExtension.java
+++ b/src/main/java/cloud/filibuster/junit/extensions/FilibusterTestExtension.java
@@ -26,12 +26,14 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.Preconditions;
 
+import static cloud.filibuster.instrumentation.helpers.Property.ASSUME_RPC_CACHING_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.DATA_NONDETERMINISM_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.MAX_ITERATIONS_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.SUPPRESS_COMBINATIONS_DEFAULT;
 import static cloud.filibuster.instrumentation.helpers.Property.getEnabledProperty;
 import static cloud.filibuster.instrumentation.helpers.Property.getServerBackendDockerImageNameProperty;
 import static cloud.filibuster.instrumentation.helpers.Property.getTestAnalysisResourceFileProperty;
+import static cloud.filibuster.instrumentation.helpers.Property.getTestAssumeRpcCachingProperty;
 import static cloud.filibuster.instrumentation.helpers.Property.getTestDataNondeterminismProperty;
 import static cloud.filibuster.instrumentation.helpers.Property.getTestMaxIterationsProperty;
 import static cloud.filibuster.instrumentation.helpers.Property.getTestSuppressCombinationsProperty;
@@ -98,6 +100,13 @@ public class FilibusterTestExtension implements TestTemplateInvocationContextPro
             dataNondeterminism = getTestDataNondeterminismProperty();
         }
 
+        boolean assumeRpcCaching = testWithFilibuster.assumeRpcCaching();
+
+        if (assumeRpcCaching == ASSUME_RPC_CACHING_DEFAULT) {
+            // Check the property to see if it was set.
+            assumeRpcCaching = getTestAssumeRpcCachingProperty();
+        }
+
         boolean suppressCombinations = testWithFilibuster.suppressCombinations();
 
         if (suppressCombinations == SUPPRESS_COMBINATIONS_DEFAULT) {
@@ -109,6 +118,7 @@ public class FilibusterTestExtension implements TestTemplateInvocationContextPro
                 .dynamicReduction(testWithFilibuster.dynamicReduction())
                 .suppressCombinations(suppressCombinations)
                 .dataNondeterminism(dataNondeterminism)
+                .assumeRpcCaching(assumeRpcCaching)
                 .serverBackend(testWithFilibuster.serverBackend())
                 .searchStrategy(testWithFilibuster.searchStrategy())
                 .dockerImageName(dockerImageName)

--- a/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
@@ -184,7 +184,7 @@ public class FilibusterCore {
         String distributedExecutionIndexString = payload.getString("execution_index");
         DistributedExecutionIndex distributedExecutionIndex = new DistributedExecutionIndexV1().deserialize(distributedExecutionIndexString);
         logger.info("[FILIBUSTER-CORE]: beginInvocation called, distributedExecutionIndex: " + distributedExecutionIndex);
-        currentConcreteTestExecution.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, payload);
+        currentConcreteTestExecution.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, payload, hasSeenRpcUnderSameOrDifferentDistributedExecutionIndex && filibusterConfiguration.getAvoidRedundantInjections());
 
         // Get next generated id.
         int generatedId = currentConcreteTestExecution.incrementGeneratedId();
@@ -206,7 +206,7 @@ public class FilibusterCore {
             }
 
             if (shouldGenerateNewAbstractExecutions && faultInjectionEnabled) {
-                if (filibusterConfiguration.getAssumeRpcCaching()) {
+                if (filibusterConfiguration.getAvoidRedundantInjections()) {
                     if (! hasSeenRpcUnderSameOrDifferentDistributedExecutionIndex) {
                         generateFaultsUsingAnalysisConfiguration(filibusterConfiguration, distributedExecutionIndex, moduleName, methodName);
                     }

--- a/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
@@ -176,6 +176,10 @@ public class FilibusterCore {
         if (currentConcreteTestExecution == null) {
             throw new FilibusterCoreLogicException("currentConcreteTestExecution should not be null at this point, something fatal occurred.");
         }
+
+        // Determine if we've seen this RPC method and arguments before.
+        boolean hasSeenRpcUnderSameOrDifferentDistributedExecutionIndex = currentConcreteTestExecution.hasSeenRpcUnderSameOrDifferentDistributedExecutionIndex(payload);
+
         // Register the RPC using the distributed execution index.
         String distributedExecutionIndexString = payload.getString("execution_index");
         DistributedExecutionIndex distributedExecutionIndex = new DistributedExecutionIndexV1().deserialize(distributedExecutionIndexString);
@@ -202,7 +206,13 @@ public class FilibusterCore {
             }
 
             if (shouldGenerateNewAbstractExecutions && faultInjectionEnabled) {
-                generateFaultsUsingAnalysisConfiguration(filibusterConfiguration, distributedExecutionIndex, moduleName, methodName);
+                if (filibusterConfiguration.getAssumeRpcCaching()) {
+                    if (! hasSeenRpcUnderSameOrDifferentDistributedExecutionIndex) {
+                        generateFaultsUsingAnalysisConfiguration(filibusterConfiguration, distributedExecutionIndex, moduleName, methodName);
+                    }
+                } else {
+                    generateFaultsUsingAnalysisConfiguration(filibusterConfiguration, distributedExecutionIndex, moduleName, methodName);
+                }
             }
         }
 

--- a/src/main/java/cloud/filibuster/junit/server/core/reports/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/reports/TestExecutionReport.java
@@ -66,7 +66,6 @@ public class TestExecutionReport {
         return new File(getDirectoryPath(), "filibuster-test-execution-" + uuid);
     }
 
-
     public boolean isTestExecutionPassed() {
         return testExecutionPassed;
     }
@@ -89,6 +88,12 @@ public class TestExecutionReport {
 
     public JSONObject getFaultObject(DistributedExecutionIndex distributedExecutionIndex) {
         return deiFaultsInjected.get(distributedExecutionIndex);
+    }
+
+    private final List<DistributedExecutionIndex> cachedRPCs = new ArrayList<DistributedExecutionIndex>();
+
+    public void markRpcAsCached(DistributedExecutionIndex distributedExecutionIndex) {
+        cachedRPCs.add(distributedExecutionIndex);
     }
 
     public void recordInvocation(
@@ -140,6 +145,7 @@ public class TestExecutionReport {
         private static final String UUID_KEY = "uuid";
         private static final String TEST_NAME = "test_name";
         private static final String ASSERTION_FAILURE_MESSAGE = "assertion_failure_message";
+        private static final String CACHED_KEY = "cached";
     }
 
     public static void addAnalyzer(Class<? extends TestExecutionReportAnalyzer> clazz) {
@@ -199,6 +205,7 @@ public class TestExecutionReport {
             RPC.put(Keys.RESPONSE_KEY, deiResponses.getOrDefault(dei, new JSONObject()));
             RPC.put(Keys.FAULT_KEY, deiFaultsInjected.getOrDefault(dei, new JSONObject()));
             RPC.put(Keys.WARNINGS_KEY, warningObjects);
+            RPC.put(Keys.CACHED_KEY, cachedRPCs.contains(dei));
             RPCs.add(RPC);
         }
 

--- a/src/main/java/cloud/filibuster/junit/server/core/reports/TestExecutionReport.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/reports/TestExecutionReport.java
@@ -92,6 +92,10 @@ public class TestExecutionReport {
 
     private final List<DistributedExecutionIndex> cachedRPCs = new ArrayList<DistributedExecutionIndex>();
 
+    public List<DistributedExecutionIndex> getCachedRPCs() {
+        return cachedRPCs;
+    }
+
     public void markRpcAsCached(DistributedExecutionIndex distributedExecutionIndex) {
         cachedRPCs.add(distributedExecutionIndex);
     }

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/ConcreteTestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/ConcreteTestExecution.java
@@ -70,8 +70,16 @@ public class ConcreteTestExecution extends TestExecution implements Cloneable {
 
     @Override
     public void addDistributedExecutionIndexWithRequestPayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload) {
+        addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, payload, /* seen= */ false);
+    }
+
+    public void addDistributedExecutionIndexWithRequestPayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload, boolean seen) {
         testExecutionReport.recordInvocation(distributedExecutionIndex, payload);
         super.addDistributedExecutionIndexWithRequestPayload(distributedExecutionIndex, payload);
+
+        if (seen) {
+            testExecutionReport.markRpcAsCached(distributedExecutionIndex);
+        }
     }
 
     @Override

--- a/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/test_executions/TestExecution.java
@@ -71,6 +71,21 @@ public abstract class TestExecution {
         logger.info(logMessage.toString());
     }
 
+    public boolean hasSeenRpcUnderSameOrDifferentDistributedExecutionIndex(JSONObject payload) {
+        JSONObject payloadCacheCleaned = cleanPayloadForCacheComparison(payload);
+
+        for (Map.Entry<DistributedExecutionIndex, JSONObject> executedRPC : executedRPCs.entrySet()) {
+            JSONObject seenPayload = executedRPC.getValue();
+            JSONObject seenPayloadCacheCleaned = cleanPayloadForCacheComparison(seenPayload);
+
+            if (seenPayloadCacheCleaned.similar(payloadCacheCleaned)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public void addDistributedExecutionIndexWithRequestPayload(DistributedExecutionIndex distributedExecutionIndex, JSONObject payload) {
         // Add to the list of executed RPCs.
         JSONObject payloadWithoutInstrumentationType = cleanPayloadOfInstrumentationType(payload);
@@ -215,6 +230,17 @@ public abstract class TestExecution {
         }
 
         return false;
+    }
+
+    private static JSONObject cleanPayloadForCacheComparison(JSONObject payload) {
+        JSONObject jsonObject = new JSONObject(payload.toString());
+        jsonObject.remove("execution_index");
+        jsonObject.remove("vclock");
+        jsonObject.remove("instrumentation_type");
+        jsonObject.remove("full_traceback");
+        jsonObject.remove("callsite_file");
+        jsonObject.remove("callsite_line");
+        return jsonObject;
     }
 
     private static JSONObject cleanPayloadOfInstrumentationType(JSONObject payload) {

--- a/src/main/proto/hello.proto
+++ b/src/main/proto/hello.proto
@@ -2,10 +2,31 @@ syntax = "proto3";
 
 package cloud.filibuster.examples;
 
+message PurchaseRequest {
+  string session_id = 1;
+}
+
+message PurchaseResponse {
+  bool success = 1;
+}
+
 service APIService {
   rpc Hello (HelloRequest) returns (HelloReply) {};
   rpc HelloWithMock (HelloRequest) returns (HelloReply) {};
   rpc RedisHello (RedisRequest) returns (RedisReply) {};
+  rpc Purchase (PurchaseRequest) returns (PurchaseResponse) {}
+}
+
+message GetUserRequest {
+  string session_id = 1;
+}
+
+message GetUserResponse {
+  string user_id = 1;
+}
+
+service UserService {
+  rpc GetUserFromSession (GetUserRequest) returns (GetUserResponse) {}
 }
 
 service HelloService {

--- a/src/main/resources/html/test_execution_report/index.html
+++ b/src/main/resources/html/test_execution_report/index.html
@@ -136,11 +136,16 @@
             padding: 0px;
             margin: 0px;
         }
+
+        .cached {
+            display: none;
+        }
 	</style>
 </head>
 
 <body>
 <section style="margin: 0; padding: 0;">
+    <span style="float: right; display: inline; text-align: right; text-decoration: none; margin-bottom: 10px; margin-left: 10px;"><a style="text-decoration: none;" href="#" onClick="toggleCached();">💵</a></span>
     <span style="float: right; display: inline; text-align: right; text-decoration: none; margin-bottom: 10px; margin-left: 10px;"><a style="text-decoration: none;" href="#" onClick="toggleDebug();">🐞</a></span>
 
     <!-- Assertion failure goes here. -->
@@ -168,6 +173,10 @@
 
             function toggleDebug() {
                 $(".debug").toggle();
+            }
+
+            function toggleCached() {
+                $(".cached").toggle();
             }
 
             function isEmpty(obj) {
@@ -227,7 +236,11 @@
                         } else if (isExceptionResponse) {
                             row += '<tr class="exception">';
                         } else {
-                            row += '<tr class="success">';
+                            if (rpc.cached) {
+                                row += '<tr class="success cached">';
+                            } else {
+                                row += '<tr class="success">';
+                            }
                         }
                     } else {
                         row += '<tr class="fault">';

--- a/src/test/java/cloud/filibuster/functional/java/cache/CacheNegativeTestByProperty.java
+++ b/src/test/java/cloud/filibuster/functional/java/cache/CacheNegativeTestByProperty.java
@@ -1,0 +1,96 @@
+package cloud.filibuster.functional.java.cache;
+
+import cloud.filibuster.examples.APIServiceGrpc;
+import cloud.filibuster.examples.Hello;
+import cloud.filibuster.examples.UserServiceGrpc;
+import cloud.filibuster.instrumentation.helpers.Networking;
+import cloud.filibuster.junit.TestWithFilibuster;
+import cloud.filibuster.junit.configuration.examples.FilibusterSingleFaultUnavailableAnalysisConfigurationFile;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import org.grpcmock.junit5.GrpcMockExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static cloud.filibuster.instrumentation.helpers.Property.setTestAssumeRpcCachingProperty;
+import static cloud.filibuster.integration.instrumentation.TestHelper.startAPIServerAndWaitUntilAvailable;
+import static cloud.filibuster.integration.instrumentation.TestHelper.stopAPIServerAndWaitUntilUnavailable;
+import static org.grpcmock.GrpcMock.stubFor;
+import static org.grpcmock.GrpcMock.unaryMethod;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CacheNegativeTestByProperty {
+    @RegisterExtension
+    static GrpcMockExtension grpcMockExtension = GrpcMockExtension.builder()
+            .withPort(Networking.getPort("user-mock"))
+            .build();
+
+    @BeforeAll
+    public static void startAllServices() throws IOException, InterruptedException {
+        startAPIServerAndWaitUntilAvailable();
+    }
+
+    @AfterAll
+    public static void stopAllServices() throws InterruptedException {
+        stopAPIServerAndWaitUntilUnavailable();
+    }
+
+    @BeforeAll
+    public static void setProperties() {
+        setTestAssumeRpcCachingProperty(false);
+    }
+
+    public static int testInvocationCount = 0;
+
+    public static int testFailures = 0;
+
+    @TestWithFilibuster(
+            dataNondeterminism = true,
+            analysisConfigurationFile = FilibusterSingleFaultUnavailableAnalysisConfigurationFile.class
+    )
+    @Order(1)
+    public void testPurchase() {
+        testInvocationCount++;
+
+        stubFor(unaryMethod(UserServiceGrpc.getGetUserFromSessionMethod())
+                .willReturn(Hello.GetUserResponse.newBuilder().setUserId("1").build()));
+
+        String sessionId = UUID.randomUUID().toString();
+
+        ManagedChannel apiChannel = ManagedChannelBuilder
+                .forAddress(Networking.getHost("api_server"), Networking.getPort("api_server"))
+                .usePlaintext()
+                .build();
+
+        try {
+            APIServiceGrpc.APIServiceBlockingStub blockingStub = APIServiceGrpc.newBlockingStub(apiChannel);
+            Hello.PurchaseRequest request = Hello.PurchaseRequest.newBuilder().setSessionId(sessionId).build();
+            Hello.PurchaseResponse response = blockingStub.purchase(request);
+            assertNotNull(response);
+        } catch (Exception e) {
+            testFailures++;
+        }
+    }
+
+    @Test
+    @Order(2)
+    public void testInvocationCount() {
+        assertEquals(4, testInvocationCount);
+    }
+
+    @Test
+    @Order(2)
+    public void testFailures() {
+        assertEquals(3, testFailures);
+    }
+}

--- a/src/test/java/cloud/filibuster/functional/java/cache/CacheNegativeTestByProperty.java
+++ b/src/test/java/cloud/filibuster/functional/java/cache/CacheNegativeTestByProperty.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.io.IOException;
 import java.util.UUID;
 
-import static cloud.filibuster.instrumentation.helpers.Property.setTestAssumeRpcCachingProperty;
+import static cloud.filibuster.instrumentation.helpers.Property.setTestAvoidRedundantInjectionsProperty;
 import static cloud.filibuster.integration.instrumentation.TestHelper.startAPIServerAndWaitUntilAvailable;
 import static cloud.filibuster.integration.instrumentation.TestHelper.stopAPIServerAndWaitUntilUnavailable;
 import static org.grpcmock.GrpcMock.stubFor;
@@ -47,7 +47,7 @@ public class CacheNegativeTestByProperty {
 
     @BeforeAll
     public static void setProperties() {
-        setTestAssumeRpcCachingProperty(false);
+        setTestAvoidRedundantInjectionsProperty(false);
     }
 
     public static int testInvocationCount = 0;
@@ -77,7 +77,7 @@ public class CacheNegativeTestByProperty {
             Hello.PurchaseRequest request = Hello.PurchaseRequest.newBuilder().setSessionId(sessionId).build();
             Hello.PurchaseResponse response = blockingStub.purchase(request);
             assertNotNull(response);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             testFailures++;
         }
     }

--- a/src/test/java/cloud/filibuster/functional/java/cache/CacheTestByAnnotation.java
+++ b/src/test/java/cloud/filibuster/functional/java/cache/CacheTestByAnnotation.java
@@ -1,0 +1,91 @@
+package cloud.filibuster.functional.java.cache;
+
+import cloud.filibuster.examples.APIServiceGrpc;
+import cloud.filibuster.examples.Hello;
+import cloud.filibuster.examples.UserServiceGrpc;
+import cloud.filibuster.instrumentation.helpers.Networking;
+import cloud.filibuster.junit.TestWithFilibuster;
+import cloud.filibuster.junit.configuration.examples.FilibusterSingleFaultUnavailableAnalysisConfigurationFile;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import org.grpcmock.junit5.GrpcMockExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static cloud.filibuster.integration.instrumentation.TestHelper.startAPIServerAndWaitUntilAvailable;
+import static cloud.filibuster.integration.instrumentation.TestHelper.stopAPIServerAndWaitUntilUnavailable;
+import static org.grpcmock.GrpcMock.stubFor;
+import static org.grpcmock.GrpcMock.unaryMethod;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CacheTestByAnnotation {
+    @RegisterExtension
+    static GrpcMockExtension grpcMockExtension = GrpcMockExtension.builder()
+            .withPort(Networking.getPort("user-mock"))
+            .build();
+
+    @BeforeAll
+    public static void startAllServices() throws IOException, InterruptedException {
+        startAPIServerAndWaitUntilAvailable();
+    }
+
+    @AfterAll
+    public static void stopAllServices() throws InterruptedException {
+        stopAPIServerAndWaitUntilUnavailable();
+    }
+
+    public static int testInvocationCount = 0;
+
+    public static int testFailures = 0;
+
+    @TestWithFilibuster(
+            dataNondeterminism = true,
+            analysisConfigurationFile = FilibusterSingleFaultUnavailableAnalysisConfigurationFile.class,
+            assumeRpcCaching = true
+    )
+    @Order(1)
+    public void testPurchase() {
+        testInvocationCount++;
+
+        stubFor(unaryMethod(UserServiceGrpc.getGetUserFromSessionMethod())
+                .willReturn(Hello.GetUserResponse.newBuilder().setUserId("1").build()));
+
+        String sessionId = UUID.randomUUID().toString();
+
+        ManagedChannel apiChannel = ManagedChannelBuilder
+                .forAddress(Networking.getHost("api_server"), Networking.getPort("api_server"))
+                .usePlaintext()
+                .build();
+
+        try {
+            APIServiceGrpc.APIServiceBlockingStub blockingStub = APIServiceGrpc.newBlockingStub(apiChannel);
+            Hello.PurchaseRequest request = Hello.PurchaseRequest.newBuilder().setSessionId(sessionId).build();
+            Hello.PurchaseResponse response = blockingStub.purchase(request);
+            assertNotNull(response);
+        } catch (Exception e) {
+            testFailures++;
+        }
+    }
+
+    @Test
+    @Order(2)
+    public void testInvocationCount() {
+        assertEquals(2, testInvocationCount);
+    }
+
+    @Test
+    @Order(2)
+    public void testFailures() {
+        assertEquals(1, testFailures);
+    }
+}

--- a/src/test/java/cloud/filibuster/functional/java/cache/CacheTestByAnnotation.java
+++ b/src/test/java/cloud/filibuster/functional/java/cache/CacheTestByAnnotation.java
@@ -51,7 +51,7 @@ public class CacheTestByAnnotation {
     @TestWithFilibuster(
             dataNondeterminism = true,
             analysisConfigurationFile = FilibusterSingleFaultUnavailableAnalysisConfigurationFile.class,
-            assumeRpcCaching = true
+            avoidRedundantInjections = true
     )
     @Order(1)
     public void testPurchase() {
@@ -72,7 +72,7 @@ public class CacheTestByAnnotation {
             Hello.PurchaseRequest request = Hello.PurchaseRequest.newBuilder().setSessionId(sessionId).build();
             Hello.PurchaseResponse response = blockingStub.purchase(request);
             assertNotNull(response);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             testFailures++;
         }
     }

--- a/src/test/java/cloud/filibuster/functional/java/cache/CacheTestByProperty.java
+++ b/src/test/java/cloud/filibuster/functional/java/cache/CacheTestByProperty.java
@@ -6,6 +6,10 @@ import cloud.filibuster.examples.UserServiceGrpc;
 import cloud.filibuster.instrumentation.helpers.Networking;
 import cloud.filibuster.junit.TestWithFilibuster;
 import cloud.filibuster.junit.configuration.examples.FilibusterSingleFaultUnavailableAnalysisConfigurationFile;
+import cloud.filibuster.junit.server.core.FilibusterCore;
+import cloud.filibuster.junit.server.core.lint.analyzers.warnings.FilibusterAnalyzerWarning;
+import cloud.filibuster.junit.server.core.lint.analyzers.warnings.RedundantRPCWarning;
+import cloud.filibuster.junit.server.core.reports.TestExecutionReport;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import org.grpcmock.junit5.GrpcMockExtension;
@@ -18,6 +22,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 import static cloud.filibuster.instrumentation.helpers.Property.setTestAvoidRedundantInjectionsProperty;
@@ -27,6 +32,7 @@ import static org.grpcmock.GrpcMock.stubFor;
 import static org.grpcmock.GrpcMock.unaryMethod;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class CacheTestByProperty {
@@ -97,5 +103,13 @@ public class CacheTestByProperty {
     @Order(2)
     public void testFailures() {
         assertEquals(1, testFailures);
+    }
+
+    @Order(2)
+    @Test
+    public void testWarnings() {
+        TestExecutionReport testExecutionReport = FilibusterCore.getMostRecentInitialTestExecutionReport();
+        List<FilibusterAnalyzerWarning> warnings = testExecutionReport.getWarnings();
+        assertEquals(0, warnings.size());
     }
 }

--- a/src/test/java/cloud/filibuster/functional/java/cache/CacheTestByProperty.java
+++ b/src/test/java/cloud/filibuster/functional/java/cache/CacheTestByProperty.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.io.IOException;
 import java.util.UUID;
 
-import static cloud.filibuster.instrumentation.helpers.Property.setTestAssumeRpcCachingProperty;
+import static cloud.filibuster.instrumentation.helpers.Property.setTestAvoidRedundantInjectionsProperty;
 import static cloud.filibuster.integration.instrumentation.TestHelper.startAPIServerAndWaitUntilAvailable;
 import static cloud.filibuster.integration.instrumentation.TestHelper.stopAPIServerAndWaitUntilUnavailable;
 import static org.grpcmock.GrpcMock.stubFor;
@@ -47,12 +47,12 @@ public class CacheTestByProperty {
 
     @BeforeAll
     public static void setProperties() {
-        setTestAssumeRpcCachingProperty(true);
+        setTestAvoidRedundantInjectionsProperty(true);
     }
 
     @AfterAll
     public static void resetProperties() {
-        setTestAssumeRpcCachingProperty(false);
+        setTestAvoidRedundantInjectionsProperty(false);
     }
 
     public static int testInvocationCount = 0;
@@ -82,7 +82,7 @@ public class CacheTestByProperty {
             Hello.PurchaseRequest request = Hello.PurchaseRequest.newBuilder().setSessionId(sessionId).build();
             Hello.PurchaseResponse response = blockingStub.purchase(request);
             assertNotNull(response);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             testFailures++;
         }
     }

--- a/src/test/java/cloud/filibuster/functional/java/cache/CacheTestByProperty.java
+++ b/src/test/java/cloud/filibuster/functional/java/cache/CacheTestByProperty.java
@@ -1,0 +1,101 @@
+package cloud.filibuster.functional.java.cache;
+
+import cloud.filibuster.examples.APIServiceGrpc;
+import cloud.filibuster.examples.Hello;
+import cloud.filibuster.examples.UserServiceGrpc;
+import cloud.filibuster.instrumentation.helpers.Networking;
+import cloud.filibuster.junit.TestWithFilibuster;
+import cloud.filibuster.junit.configuration.examples.FilibusterSingleFaultUnavailableAnalysisConfigurationFile;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import org.grpcmock.junit5.GrpcMockExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static cloud.filibuster.instrumentation.helpers.Property.setTestAssumeRpcCachingProperty;
+import static cloud.filibuster.integration.instrumentation.TestHelper.startAPIServerAndWaitUntilAvailable;
+import static cloud.filibuster.integration.instrumentation.TestHelper.stopAPIServerAndWaitUntilUnavailable;
+import static org.grpcmock.GrpcMock.stubFor;
+import static org.grpcmock.GrpcMock.unaryMethod;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CacheTestByProperty {
+    @RegisterExtension
+    static GrpcMockExtension grpcMockExtension = GrpcMockExtension.builder()
+            .withPort(Networking.getPort("user-mock"))
+            .build();
+
+    @BeforeAll
+    public static void startAllServices() throws IOException, InterruptedException {
+        startAPIServerAndWaitUntilAvailable();
+    }
+
+    @AfterAll
+    public static void stopAllServices() throws InterruptedException {
+        stopAPIServerAndWaitUntilUnavailable();
+    }
+
+    @BeforeAll
+    public static void setProperties() {
+        setTestAssumeRpcCachingProperty(true);
+    }
+
+    @AfterAll
+    public static void resetProperties() {
+        setTestAssumeRpcCachingProperty(false);
+    }
+
+    public static int testInvocationCount = 0;
+
+    public static int testFailures = 0;
+
+    @TestWithFilibuster(
+            dataNondeterminism = true,
+            analysisConfigurationFile = FilibusterSingleFaultUnavailableAnalysisConfigurationFile.class
+    )
+    @Order(1)
+    public void testPurchase() {
+        testInvocationCount++;
+
+        stubFor(unaryMethod(UserServiceGrpc.getGetUserFromSessionMethod())
+                .willReturn(Hello.GetUserResponse.newBuilder().setUserId("1").build()));
+
+        String sessionId = UUID.randomUUID().toString();
+
+        ManagedChannel apiChannel = ManagedChannelBuilder
+                .forAddress(Networking.getHost("api_server"), Networking.getPort("api_server"))
+                .usePlaintext()
+                .build();
+
+        try {
+            APIServiceGrpc.APIServiceBlockingStub blockingStub = APIServiceGrpc.newBlockingStub(apiChannel);
+            Hello.PurchaseRequest request = Hello.PurchaseRequest.newBuilder().setSessionId(sessionId).build();
+            Hello.PurchaseResponse response = blockingStub.purchase(request);
+            assertNotNull(response);
+        } catch (Exception e) {
+            testFailures++;
+        }
+    }
+
+    @Test
+    @Order(2)
+    public void testInvocationCount() {
+        assertEquals(2, testInvocationCount);
+    }
+
+    @Test
+    @Order(2)
+    public void testFailures() {
+        assertEquals(1, testFailures);
+    }
+}


### PR DESCRIPTION
Add option to assume that RPCs are cached and avoid FI of repeated invocations for the same method and arguments.