### PR TITLE
Fix ordering of writes.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.7.1:
+   - (cmeiklejohn) Fix ordering of writes of the UX report.
 1.7.0:
    - (cmeiklejohn) Bug fix for UX rendering of failures.
    - (MichaelA-ops) Add prototype Redis fault injection support.

--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ javadoc {
 
 group = "cloud.filibuster"
 archivesBaseName = "instrumentation"
-version = "1.7.0"
+version = "1.7.1"
 
 java {
     withJavadocJar()

--- a/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
+++ b/src/main/java/cloud/filibuster/junit/server/core/FilibusterCore.java
@@ -71,9 +71,6 @@ public class FilibusterCore {
         currentConcreteTestExecution = new ConcreteTestExecution(testName, testUUID, className);
         this.filibusterConfiguration = filibusterConfiguration;
 
-        this.testReport = new TestReport(testName, testUUID, className);
-        testReport.writeOutPlaceholder();
-
         if (filibusterConfiguration.getSearchStrategy() == FilibusterSearchStrategy.DFS) {
             this.exploredTestExecutions = new TestExecutionStack<>();
             this.unexploredTestExecutions = new TestExecutionStack<>();
@@ -83,8 +80,13 @@ public class FilibusterCore {
         } else {
             throw new FilibusterCoreLogicException("Unsupported search strategy: " + filibusterConfiguration.getSearchStrategy());
         }
-        // This statement ensures the placeholders and written
+
+        // This statement clears out /tmp/filibuster and sets up the execution.
         TestSuiteReport.getInstance();
+
+        // This statement writes out the place holder for the report
+        this.testReport = new TestReport(testName, testUUID, className);
+        testReport.writeOutPlaceholder();
     }
 
     // Aggregate test execution report.


### PR DESCRIPTION
This fixes an issue where /tmp/filibuster/test-id is written out, removed when the placeholder is written as part of TestSuite initialization is written by removal of all files in /tmp/filibuster, and then we attempt to write /tmp/filibuster/test-id/X which fails because the directory path doesn't exist.