### PR TITLE
Use fully qualified method names in callsites

### DIFF
--- a/src/main/java/cloud/filibuster/instrumentation/libraries/lettuce/RedisInterceptor.java
+++ b/src/main/java/cloud/filibuster/instrumentation/libraries/lettuce/RedisInterceptor.java
@@ -1,6 +1,7 @@
 package cloud.filibuster.instrumentation.libraries.lettuce;
 
 import javax.annotation.Nullable;
+
 import cloud.filibuster.exceptions.filibuster.FilibusterFaultInjectionException;
 import cloud.filibuster.exceptions.filibuster.FilibusterRuntimeException;
 import cloud.filibuster.instrumentation.datatypes.Callsite;
@@ -85,8 +86,11 @@ public class RedisInterceptor<T> implements MethodInterceptor {
         // Extract callsite information.
         // ******************************************************************************************
 
-        // Possible Redis methods are RedisClient/get, RedisClient/set, RedisClient/sync, RedisClient/async, ...
-        String redisFullMethodName = REDIS_MODULE_NAME + "/" + invocation.getMethod().getName();
+        // Possible values of redisFullMethodName are
+        //  RedisClient/io.lettuce.core.api.sync.RedisStringCommands.get,
+        //  RedisClient/io.lettuce.core.api.async.RedisStringAsyncCommands.get,
+        //  RedisClient/io.lettuce.core.api.StatefulRedisConnection.sync
+        String redisFullMethodName = String.format("%s/%s.%s", REDIS_MODULE_NAME, invocation.getMethod().getDeclaringClass().getName(), invocation.getMethod().getName());
         logger.log(Level.INFO, logPrefix + "redisFullMethodName: " + redisFullMethodName);
 
         // ******************************************************************************************

--- a/src/main/java/cloud/filibuster/junit/configuration/examples/redis/RedisDefaultAnalysisConfigurationFile.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/examples/redis/RedisDefaultAnalysisConfigurationFile.java
@@ -24,11 +24,11 @@ public class RedisDefaultAnalysisConfigurationFile implements FilibusterAnalysis
 
         createException(filibusterCustomAnalysisConfigurationFileBuilder,
                 "io.lettuce.core.RedisCommandTimeoutException",
-                "/(get|set)\\b",
+                "/(io.lettuce.core.api.sync.RedisStringCommands.get|io.lettuce.core.api.sync.RedisStringCommands.set)\\b",
                 "Command timed out after 100 millisecond(s)");
         createException(filibusterCustomAnalysisConfigurationFileBuilder,
                 "io.lettuce.core.RedisConnectionException",
-                "/(sync|async)\\b",
+                "/(io.lettuce.core.api.StatefulRedisConnection.sync|io.lettuce.core.api.StatefulRedisConnection.async)\\b",
                 "Connection closed prematurely");
 
         filibusterCustomAnalysisConfigurationFile = filibusterCustomAnalysisConfigurationFileBuilder.build();

--- a/src/main/java/cloud/filibuster/junit/configuration/examples/redis/RedisExhaustiveAnalysisConfigurationFile.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/examples/redis/RedisExhaustiveAnalysisConfigurationFile.java
@@ -23,14 +23,41 @@ public class RedisExhaustiveAnalysisConfigurationFile implements FilibusterAnaly
         FilibusterCustomAnalysisConfigurationFile.Builder filibusterCustomAnalysisConfigurationFileBuilder = new FilibusterCustomAnalysisConfigurationFile.Builder();
 
         String[][] exceptions = new String[][]{
-                {"io.lettuce.core.RedisCommandTimeoutException", "/(get|set|hget|hset|hgetall)\\b", "Command timed out after 100 millisecond(s)"},
-                {"io.lettuce.core.RedisConnectionException", "/(sync|async)\\b", "Connection closed prematurely"},
-                {"io.lettuce.core.RedisBusyException", "/(flushall|flushdb)\\b", "BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE"},
-                {"io.lettuce.core.RedisCommandExecutionException", "/(hget|hgetall|hset)\\b", "WRONGTYPE Operation against a key holding the wrong kind of value"},
-                {"io.lettuce.core.RedisCommandInterruptedException", "/(await)\\b", "Command interrupted"},
-                {"io.lettuce.core.cluster.UnknownPartitionException", "/(getConnection)\\b", "Connection not allowed. This partition is not known in the cluster view"},
-                {"io.lettuce.core.cluster.PartitionSelectorException", "/(getConnection)\\b", "Cannot determine a partition to read for slot"},
-                {"io.lettuce.core.dynamic.batch.BatchException", "/(flush)\\b", "Error during batch command execution"},
+                {"io.lettuce.core.RedisCommandTimeoutException",
+                        "/(io.lettuce.core.api.async.RedisStringAsyncCommands.get|" +
+                                "io.lettuce.core.api.sync.RedisStringCommands.get|" +
+                                "io.lettuce.core.api.sync.RedisStringCommands.set|" +
+                                "io.lettuce.core.api.sync.RedisHashCommands.hget|" +
+                                "io.lettuce.core.api.sync.RedisHashCommands.hset|" +
+                                "io.lettuce.core.api.sync.RedisHashCommands.hgetall)\\b",
+                        "Command timed out after 100 millisecond(s)"},
+                {"io.lettuce.core.RedisConnectionException",
+                        "/(io.lettuce.core.api.StatefulRedisConnection.sync|" +
+                                "io.lettuce.core.api.StatefulRedisConnection.async)\\b",
+                        "Connection closed prematurely"},
+                {"io.lettuce.core.RedisBusyException",
+                        "/(io.lettuce.core.api.sync.RedisServerCommands.flushall|" +
+                                "io.lettuce.core.api.sync.RedisServerCommands.flushdb)\\b",
+                        "BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE"},
+                {"io.lettuce.core.RedisCommandExecutionException",
+                        "/(io.lettuce.core.api.sync.RedisHashCommands.hget|" +
+                                "io.lettuce.core.api.sync.RedisHashCommands.hset|" +
+                                "io.lettuce.core.api.sync.RedisHashCommands.hgetall)\\b",
+                        "WRONGTYPE Operation against a key holding the wrong kind of value"},
+                {"io.lettuce.core.RedisCommandInterruptedException",
+                        "/(io.lettuce.core.RedisFuture.await)\\b",
+                        "Command interrupted"},
+                {"io.lettuce.core.cluster.UnknownPartitionException",
+                        "/(io.lettuce.core.cluster.RedisClusterClient.getConnection|" +
+                                "io.lettuce.core.cluster.PooledClusterConnectionProvider.getConnection)\\b",
+                        "Connection not allowed. This partition is not known in the cluster view"},
+                {"io.lettuce.core.cluster.PartitionSelectorException",
+                        "/(io.lettuce.core.cluster.RedisClusterClient.getConnection|" +
+                                "io.lettuce.core.cluster.PooledClusterConnectionProvider.getConnection)\\b",
+                        "Cannot determine a partition to read for slot"},
+                {"io.lettuce.core.dynamic.batch.BatchException",
+                        "/(io.lettuce.core.dynamic.SimpleBatcher.flush)\\b",
+                        "Error during batch command execution"},
         };
 
         for (String[] exception : exceptions) {

--- a/src/main/java/cloud/filibuster/junit/configuration/examples/redis/RedisSingleFaultCommandInterruptedExceptionAnalysisConfigurationFile.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/examples/redis/RedisSingleFaultCommandInterruptedExceptionAnalysisConfigurationFile.java
@@ -24,7 +24,7 @@ public class RedisSingleFaultCommandInterruptedExceptionAnalysisConfigurationFil
 
         FilibusterAnalysisConfiguration.Builder filibusterAnalysisConfigurationBuilderRedisExceptions = new FilibusterAnalysisConfiguration.Builder()
                 .name("io.lettuce.core.RedisCommandInterruptedException")
-                .pattern(REDIS_MODULE_NAME + "/(await)\\b");
+                .pattern(REDIS_MODULE_NAME + "/(io.lettuce.core.RedisFuture.await)\\b");
 
         filibusterAnalysisConfigurationBuilderRedisExceptions.exception("io.lettuce.core.RedisCommandInterruptedException", createErrorMap());
 

--- a/src/main/java/cloud/filibuster/junit/configuration/examples/redis/RedisSingleFaultCommandTimeoutExceptionAnalysisConfigurationFile.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/examples/redis/RedisSingleFaultCommandTimeoutExceptionAnalysisConfigurationFile.java
@@ -24,7 +24,7 @@ public class RedisSingleFaultCommandTimeoutExceptionAnalysisConfigurationFile im
 
         FilibusterAnalysisConfiguration.Builder filibusterAnalysisConfigurationBuilderRedisExceptions = new FilibusterAnalysisConfiguration.Builder()
                 .name("io.lettuce.core.RedisCommandTimeoutException")
-                .pattern(REDIS_MODULE_NAME + "/(get|set)\\b");
+                .pattern(REDIS_MODULE_NAME + "/(io.lettuce.core.api.sync.RedisStringCommands.get|io.lettuce.core.api.sync.RedisStringCommands.set)\\b");
 
         filibusterAnalysisConfigurationBuilderRedisExceptions.exception("io.lettuce.core.RedisCommandTimeoutException", createErrorMap());
 

--- a/src/main/java/cloud/filibuster/junit/configuration/examples/redis/byzantine/RedisSingleGetBasicStringByzantineFaultAnalysisConfigurationFile.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/examples/redis/byzantine/RedisSingleGetBasicStringByzantineFaultAnalysisConfigurationFile.java
@@ -24,7 +24,7 @@ public class RedisSingleGetBasicStringByzantineFaultAnalysisConfigurationFile im
 
         FilibusterAnalysisConfiguration.Builder filibusterAnalysisConfigurationBuilderRedisExceptions = new FilibusterAnalysisConfiguration.Builder()
                 .name("java.lettuce.byzantine.basic_string")
-                .pattern(REDIS_MODULE_NAME + "/(get)\\b");
+                .pattern(REDIS_MODULE_NAME + "/(io.lettuce.core.api.sync.RedisStringCommands.get)\\b");
 
 
         String[] possibleValues = {null, ""};

--- a/src/main/java/cloud/filibuster/junit/configuration/examples/redis/byzantine/RedisSingleGetByteArrByzantineFaultAnalysisConfigurationFile.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/examples/redis/byzantine/RedisSingleGetByteArrByzantineFaultAnalysisConfigurationFile.java
@@ -25,7 +25,7 @@ public class RedisSingleGetByteArrByzantineFaultAnalysisConfigurationFile implem
 
         FilibusterAnalysisConfiguration.Builder filibusterAnalysisConfigurationBuilderRedisExceptions = new FilibusterAnalysisConfiguration.Builder()
                 .name("java.lettuce.byzantine.byte_arr")
-                .pattern(REDIS_MODULE_NAME + "/(get)\\b");
+                .pattern(REDIS_MODULE_NAME + "/(io.lettuce.core.api.sync.RedisStringCommands.get)\\b");
 
 
         String[] possibleValues = {"", "ThisIsATestString", "abcd", "1234!!", "-11"};

--- a/src/main/java/cloud/filibuster/junit/configuration/examples/redis/byzantine/RedisSingleGetStringByzantineFaultAnalysisConfigurationFile.java
+++ b/src/main/java/cloud/filibuster/junit/configuration/examples/redis/byzantine/RedisSingleGetStringByzantineFaultAnalysisConfigurationFile.java
@@ -24,7 +24,7 @@ public class RedisSingleGetStringByzantineFaultAnalysisConfigurationFile impleme
 
         FilibusterAnalysisConfiguration.Builder filibusterAnalysisConfigurationBuilderRedisExceptions = new FilibusterAnalysisConfiguration.Builder()
                 .name("java.lettuce.byzantine.string")
-                .pattern(REDIS_MODULE_NAME + "/(get)\\b");
+                .pattern(REDIS_MODULE_NAME + "/(io.lettuce.core.api.sync.RedisStringCommands.get)\\b");
 
 
         // Potentially use junit-quickcheck to generate the possible values -> Would make the tests more "flaky"

--- a/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterBuggyFallbackByzantineTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterBuggyFallbackByzantineTest.java
@@ -47,7 +47,7 @@ public class JUnitRedisFilibusterBuggyFallbackByzantineTest {
         } catch (Throwable t) {
             if (wasFaultInjected()) {
                 assertTrue(wasFaultInjectedOnService(REDIS_MODULE_NAME), "Fault was not injected on the Redis module");
-                assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "get"), "Fault was not injected on the expected Redis method");
+                assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "io.lettuce.core.api.sync.RedisStringCommands.get"), "Fault was not injected on the expected Redis method");
                 String expectedErrorMessage = "INTERNAL: INTERNAL: java.lang.Exception: An exception was thrown at Hello service\n" +
                         "MyAPIService could not process the request as an exception was thrown";
                 assertTrue(t.getMessage().contains(expectedErrorMessage), "Unexpected return error message for injected byzantine fault");

--- a/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterByzantineByteArrTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterByzantineByteArrTest.java
@@ -66,7 +66,7 @@ public class JUnitRedisFilibusterByzantineByteArrTest extends JUnitAnnotationBas
             String returnValStr = new String(returnVal, Charset.defaultCharset());
             assertTrue(expectedValues.contains(returnValStr), "An unexpected value was returned: " + returnValStr);
             assertTrue(wasFaultInjectedOnService(REDIS_MODULE_NAME), "Fault was not injected on the Redis module");
-            assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "get"), "Fault was not injected on the expected Redis method");
+            assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "io.lettuce.core.api.sync.RedisStringCommands.get"), "Fault was not injected on the expected Redis method");
         }
     }
 

--- a/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterByzantineStringTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterByzantineStringTest.java
@@ -60,7 +60,7 @@ public class JUnitRedisFilibusterByzantineStringTest extends JUnitAnnotationBase
             actualValues.add(returnVal);
             assertTrue(expectedValues.contains(returnVal), "An unexpected value was returned: " + returnVal);
             assertTrue(wasFaultInjectedOnService(REDIS_MODULE_NAME), "Fault was not injected on the Redis module");
-            assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "get"), "Fault was not injected on the expected Redis method");
+            assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "io.lettuce.core.api.sync.RedisStringCommands.get"), "Fault was not injected on the expected Redis method");
         }
     }
 

--- a/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterExhaustiveCoreExceptionsTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterExhaustiveCoreExceptionsTest.java
@@ -72,19 +72,29 @@ public class JUnitRedisFilibusterExhaustiveCoreExceptionsTest extends JUnitAnnot
 
     static {
         allowedExceptions.put(RedisCommandTimeoutException.class,
-                new AbstractMap.SimpleEntry<>(Arrays.asList("get", "hgetall", "hset"), "Command timed out after 100 millisecond(s)"));
+                new AbstractMap.SimpleEntry<>(Arrays.asList("io.lettuce.core.api.sync.RedisStringCommands.get",
+                        "io.lettuce.core.api.async.RedisStringAsyncCommands.get",
+                        "io.lettuce.core.api.sync.RedisHashCommands.hgetall",
+                        "io.lettuce.core.api.sync.RedisHashCommands.hset"), "Command timed out after 100 millisecond(s)"));
 
         allowedExceptions.put(RedisConnectionException.class,
-                new AbstractMap.SimpleEntry<>(Arrays.asList("sync", "async"), "Connection closed prematurely"));
+                new AbstractMap.SimpleEntry<>(Arrays.asList("io.lettuce.core.api.StatefulRedisConnection.sync",
+                        "io.lettuce.core.api.StatefulRedisConnection.async"),
+                        "Connection closed prematurely"));
 
         allowedExceptions.put(RedisBusyException.class,
-                new AbstractMap.SimpleEntry<>(Arrays.asList("flushall", "flushdb"), "BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE"));
+                new AbstractMap.SimpleEntry<>(Arrays.asList("io.lettuce.core.api.sync.RedisServerCommands.flushall",
+                        "io.lettuce.core.api.sync.RedisServerCommands.flushdb"),
+                        "BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE"));
 
         allowedExceptions.put(RedisCommandExecutionException.class,
-                new AbstractMap.SimpleEntry<>(Arrays.asList("hgetall", "hset"), "WRONGTYPE Operation against a key holding the wrong kind of value"));
+                new AbstractMap.SimpleEntry<>(Arrays.asList("io.lettuce.core.api.sync.RedisHashCommands.hgetall",
+                        "io.lettuce.core.api.sync.RedisHashCommands.hset"),
+                        "WRONGTYPE Operation against a key holding the wrong kind of value"));
 
         allowedExceptions.put(RedisCommandInterruptedException.class,
-                new AbstractMap.SimpleEntry<>(Collections.singletonList("await"), "Command interrupted"));
+                new AbstractMap.SimpleEntry<>(Collections.singletonList("io.lettuce.core.RedisFuture.await"),
+                        "Command interrupted"));
 
     }
 

--- a/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterRetryTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterRetryTest.java
@@ -52,7 +52,7 @@ public class JUnitRedisFilibusterRetryTest {
         } catch (Throwable t) {
             if (wasFaultInjected()) {
                 assertTrue(wasFaultInjectedOnService(REDIS_MODULE_NAME), "Fault was not injected on the Redis module");
-                assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "await"), "Fault was not injected on the expected Redis method");
+                assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "io.lettuce.core.RedisFuture.await"), "Fault was not injected on the expected Redis method");
                 String expectedErrorMessage = "Command interrupted";
                 assertTrue(t.getMessage().contains(expectedErrorMessage), "Unexpected return error message for injected byzantine fault");
             } else {

--- a/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterSyncGetDefaultTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterSyncGetDefaultTest.java
@@ -71,7 +71,7 @@ public class JUnitRedisFilibusterSyncGetDefaultTest extends JUnitAnnotationBaseT
 
             assertTrue(wasFaultInjected(), "An exception was thrown although no fault was injected." + t);
             assertTrue(wasFaultInjectedOnService(REDIS_MODULE_NAME), "Fault was not injected on the Redis module." + t);
-            assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "sync") || wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "get"), "Fault was not injected on the Redis module." + t);
+            assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "io.lettuce.core.api.StatefulRedisConnection.sync") || wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "io.lettuce.core.api.sync.RedisStringCommands.get"), "Fault was not injected on the Redis module." + t);
             assertTrue(t instanceof RedisCommandTimeoutException || t instanceof RedisConnectionException, "Fault was not of the correct type" + t);
             assertTrue(allowedExceptionMessages.contains(t.getMessage()), "Unexpected fault message" + t);
         }

--- a/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterSyncGetNonExistingKeyTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterSyncGetNonExistingKeyTest.java
@@ -70,7 +70,7 @@ public class JUnitRedisFilibusterSyncGetNonExistingKeyTest extends JUnitAnnotati
 
             assertTrue(wasFaultInjected(), "An exception was thrown although no fault was injected: " + t);
             assertTrue(wasFaultInjectedOnService(REDIS_MODULE_NAME), "Fault was not injected on the Redis module: " + t);
-            assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "get"), "Fault was not injected on the expected Redis method: " + t);
+            assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "io.lettuce.core.api.sync.RedisStringCommands.get"), "Fault was not injected on the expected Redis method: " + t);
             assertTrue(t instanceof RedisCommandTimeoutException, "Fault was not of the correct type: " + t);
             assertTrue(allowedExceptionMessages.contains(t.getMessage()), "Unexpected fault message: " + t);
         }

--- a/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterSyncGetTest.java
+++ b/src/test/java/cloud/filibuster/functional/java/redis/JUnitRedisFilibusterSyncGetTest.java
@@ -69,7 +69,7 @@ public class JUnitRedisFilibusterSyncGetTest extends JUnitAnnotationBaseTest {
 
             assertTrue(wasFaultInjected(), "An exception was thrown although no fault was injected: " + t);
             assertTrue(wasFaultInjectedOnService(REDIS_MODULE_NAME), "Fault was not injected on the Redis module: " + t);
-            assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "get"), "Fault was not injected on the expected Redis method: " + t);
+            assertTrue(wasFaultInjectedOnMethod(REDIS_MODULE_NAME, "io.lettuce.core.api.sync.RedisStringCommands.get"), "Fault was not injected on the expected Redis method: " + t);
             assertTrue(t instanceof RedisCommandTimeoutException, "Fault was not of the correct type: " + t);
             assertTrue(allowedExceptionMessages.contains(t.getMessage()), "Unexpected fault message: " + t);
         }


### PR DESCRIPTION
Closes #153 

This PR adjusts the callsite in the RedisInterceptor to communicate the fully qualified method names (`io.lettuce.core.api.sync.RedisStringCommands.get`) instead of the bare names (`get`). It also updates the pattern matching regex in the Redis analysis configuration files and the unit tests.